### PR TITLE
Validate Cloud SDK and Java components before use

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/AppEngineJavaComponentsNotInstalledException.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/AppEngineJavaComponentsNotInstalledException.java
@@ -23,7 +23,7 @@ import com.google.cloud.tools.appengine.api.AppEngineException;
  */
 public class AppEngineJavaComponentsNotInstalledException extends AppEngineException {
 
-  AppEngineJavaComponentsNotInstalledException(String message) {
+  public AppEngineJavaComponentsNotInstalledException(String message) {
     super(message);
   }
 

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -141,11 +141,8 @@ public class CloudSdk {
    */
   public void runDevAppServerCommand(List<String> args) throws ProcessRunnerException {
     validateCloudSdk();
-    if (!Files.isRegularFile(getDevAppServerPath())) {
-      throw new AppEngineException(
-          "Validation Error: dev_appserver.py location '"
-              + getDevAppServerPath() + "' is not a file.");
-    }
+    // TODO: remove this check when the auto-install for Java is fixed in dev_appserver.py
+    validateAppEngineJavaComponents();
 
     List<String> command = new ArrayList<>();
 
@@ -263,6 +260,11 @@ public class CloudSdk {
     if (!Files.isRegularFile(getGCloudPath())) {
       throw new CloudSdkNotFoundException(
           "Validation Error: gcloud location '" + getGCloudPath() + "' is not a file.");
+    }
+    if (!Files.isRegularFile(getDevAppServerPath())) {
+      throw new CloudSdkNotFoundException(
+          "Validation Error: dev_appserver.py location '"
+              + getDevAppServerPath() + "' is not a file.");
     }
   }
 

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -251,7 +251,7 @@ public class CloudSdk {
    */
   public void validateCloudSdk() throws CloudSdkNotFoundException {
     if (sdkPath == null) {
-      throw new CloudSdkNotFoundException("Validation Error: SDK path is null");
+      throw new CloudSdkNotFoundException("Validation Error: Cloud SDK path is null");
     }
     if (!Files.isDirectory(sdkPath)) {
       throw new CloudSdkNotFoundException(
@@ -279,7 +279,8 @@ public class CloudSdk {
       throws AppEngineJavaComponentsNotInstalledException {
     if (!Files.isDirectory(getJavaAppEngineSdkPath())) {
       throw new AppEngineJavaComponentsNotInstalledException(
-          "Validation Error: Java App Engine components not installed");
+          "Validation Error: Java App Engine components not installed."
+              + " Fix by running 'gcloud components install app-engine-java' on command-line.");
     }
     if (!Files.isRegularFile(JAR_LOCATIONS.get(JAVA_TOOLS_JAR))) {
       throw new AppEngineJavaComponentsNotInstalledException(

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -101,8 +101,11 @@ public class CloudSdk {
    * Uses the process runner to execute the gcloud app command with the provided arguments.
    *
    * @param args The arguments to pass to "gcloud app" command.
+   * @throws CloudSdkNotFoundException when the Cloud SDK is not installed where expected
    */
   public void runAppCommand(List<String> args) throws ProcessRunnerException {
+    validateCloudSdk();
+
     List<String> command = new ArrayList<>();
     command.add(getGCloudPath().toString());
     command.add("app");
@@ -131,10 +134,19 @@ public class CloudSdk {
    * Uses the process runner to execute a dev_appserver.py command.
    *
    * @param args the arguments to pass to dev_appserver.py
-   * @throws InvalidPathException when Python can't be located
-   * @throws ProcessRunnerException when process runner encounters an error
+   * @throws InvalidPathException      when Python can't be located
+   * @throws ProcessRunnerException    when process runner encounters an error
+   * @throws CloudSdkNotFoundException when the Cloud SDK is not installed where expected
+   * @throws AppEngineException        when dev_appserver.py cannot be found
    */
   public void runDevAppServerCommand(List<String> args) throws ProcessRunnerException {
+    validateCloudSdk();
+    if (!Files.isRegularFile(getDevAppServerPath())) {
+      throw new AppEngineException(
+          "Validation Error: dev_appserver.py location '"
+              + getDevAppServerPath() + "' is not a file.");
+    }
+
     List<String> command = new ArrayList<>();
 
     if (IS_WINDOWS) {
@@ -156,8 +168,13 @@ public class CloudSdk {
 
   /**
    * Executes an App Engine SDK CLI command.
+   *
+   * @throws AppEngineJavaComponentsNotInstalledException when the App Engine Java components are
+   *                                                      not installed in the Cloud SDK
    */
   public void runAppCfgCommand(List<String> args) throws ProcessRunnerException {
+    validateAppEngineJavaComponents();
+
     // AppEngineSdk requires this system property to be set.
     System.setProperty("appengine.sdk.root", getJavaAppEngineSdkPath().toString());
 
@@ -210,13 +227,13 @@ public class CloudSdk {
         throw new InvalidPathException(cloudSdkPython, "python binary not in specified location");
       }
     }
-    
+
     Path pythonPath = getSdkPath().resolve(WINDOWS_BUNDLED_PYTHON);
     if (Files.exists(pythonPath)) {
       return pythonPath;
     } else {
       return Paths.get("python");
-    } 
+    }
 
   }
 
@@ -231,36 +248,39 @@ public class CloudSdk {
   }
 
   /**
-   * Checks whether the Cloud SDK Path with necessary components is installed in
-   * the expected location.
+   * Checks whether the Cloud SDK Path with is valid.
    *
-   * @throws AppEngineJavaComponentsNotInstalledException when the App Engine Java 
-   *     components are not installed in the Cloud SDK
-   * @throws AppEngineException when the Cloud SDK is not installed where expected
+   * @throws CloudSdkNotFoundException when the Cloud SDK is not installed where expected
    */
-  public void validate() throws AppEngineException {
+  public void validateCloudSdk() throws CloudSdkNotFoundException {
     if (sdkPath == null) {
-      throw new AppEngineException("Validation Error: SDK path is null");
+      throw new CloudSdkNotFoundException("Validation Error: SDK path is null");
     }
     if (!Files.isDirectory(sdkPath)) {
-      throw new AppEngineException(
+      throw new CloudSdkNotFoundException(
           "Validation Error: SDK location '" + sdkPath + "' is not a directory.");
     }
     if (!Files.isRegularFile(getGCloudPath())) {
-      throw new AppEngineException(
+      throw new CloudSdkNotFoundException(
           "Validation Error: gcloud location '" + getGCloudPath() + "' is not a file.");
     }
-    if (!Files.isRegularFile(getDevAppServerPath())) {
-      throw new AppEngineException(
-          "Validation Error: dev_appserver.py location '"
-              + getDevAppServerPath() + "' is not a file.");
-    }
+  }
+
+  /**
+   * Checks whether the App Engine Java components are installed in the expected location in the
+   * Cloud SDK.
+   *
+   * @throws AppEngineJavaComponentsNotInstalledException when the App Engine Java components are
+   *                                                      not installed in the Cloud SDK
+   */
+  public void validateAppEngineJavaComponents()
+      throws AppEngineJavaComponentsNotInstalledException {
     if (!Files.isDirectory(getJavaAppEngineSdkPath())) {
       throw new AppEngineJavaComponentsNotInstalledException(
           "Validation Error: Java App Engine components not installed");
     }
     if (!Files.isRegularFile(JAR_LOCATIONS.get(JAVA_TOOLS_JAR))) {
-      throw new AppEngineException(
+      throw new AppEngineJavaComponentsNotInstalledException(
           "Validation Error: Java Tools jar location '"
               + JAR_LOCATIONS.get(JAVA_TOOLS_JAR) + "' is not a file.");
     }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkNotFoundException.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkNotFoundException.java
@@ -23,7 +23,7 @@ import com.google.cloud.tools.appengine.api.AppEngineException;
  */
 public class CloudSdkNotFoundException extends AppEngineException {
 
-  CloudSdkNotFoundException(String message) {
+  public CloudSdkNotFoundException(String message) {
     super(message);
   }
 

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkNotFoundException.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkNotFoundException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.appengine.cloudsdk;
+
+import com.google.cloud.tools.appengine.api.AppEngineException;
+
+/**
+ * User needs to use a valid Cloud SDK installation.
+ */
+public class CloudSdkNotFoundException extends AppEngineException {
+
+  CloudSdkNotFoundException(String message) {
+    super(message);
+  }
+
+}


### PR DESCRIPTION
@etanshaul @patflynn @loosebazooka @elharo 

I split the validation up into validating Cloud SDK separately from the Java components, and created a separate exception for when Cloud SDK is not found.
I also made the checks happen by default in the methods where the corresponding components are used.