### PR TITLE
Make JAVA_HOME configurable on the devappserver child process

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/api/devserver/DefaultRunConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/devserver/DefaultRunConfiguration.java
@@ -46,6 +46,7 @@ public class DefaultRunConfiguration implements RunConfiguration {
   private String devAppserverLogLevel;
   private Boolean skipSdkUpdateCheck;
   private String defaultGcsBucketName;
+  private String javaHomeDir;
 
   @Override
   public List<File> getAppYamls() {
@@ -243,5 +244,14 @@ public class DefaultRunConfiguration implements RunConfiguration {
 
   public void setDefaultGcsBucketName(String defaultGcsBucketName) {
     this.defaultGcsBucketName = defaultGcsBucketName;
+  }
+
+  @Override
+  public String getJavaHomeDir() {
+    return javaHomeDir;
+  }
+
+  public void setJavaHomeDir(String javaHomeDir) {
+    this.javaHomeDir = javaHomeDir;
   }
 }

--- a/src/main/java/com/google/cloud/tools/appengine/api/devserver/RunConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/devserver/RunConfiguration.java
@@ -68,4 +68,6 @@ public interface RunConfiguration {
   Boolean getSkipSdkUpdateCheck();
 
   String getDefaultGcsBucketName();
+
+  String getJavaHomeDir();
 }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -27,6 +27,7 @@ import com.google.cloud.tools.appengine.cloudsdk.process.ProcessOutputLineListen
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessStartListener;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -140,6 +141,22 @@ public class CloudSdk {
    * @throws AppEngineException        when dev_appserver.py cannot be found
    */
   public void runDevAppServerCommand(List<String> args) throws ProcessRunnerException {
+    runDevAppServerCommand(args, new HashMap<String, String>());
+  }
+
+  /**
+   * Uses the process runner to execute a dev_appserver.py command.
+   *
+   * @param args the arguments to pass to dev_appserver.py
+   * @param environment map of environment variables to set for the dev_appserver process
+   * @throws InvalidPathException      when Python can't be located
+   * @throws ProcessRunnerException    when process runner encounters an error
+   * @throws CloudSdkNotFoundException when the Cloud SDK is not installed where expected
+   * @throws AppEngineException        when dev_appserver.py cannot be found
+   */
+  public void runDevAppServerCommand(List<String> args, Map<String,String> environment)
+      throws ProcessRunnerException {
+    Preconditions.checkNotNull(environment);
     validateCloudSdk();
 
     List<String> command = new ArrayList<>();
@@ -154,10 +171,9 @@ public class CloudSdk {
     logCommand(command);
 
     // set quiet mode and consequently auto-install of app-engine-java component
-    Map<String, String> environment = Maps.newHashMap();
     environment.put("CLOUDSDK_CORE_DISABLE_PROMPTS", "1");
-    processRunner.setEnvironment(environment);
 
+    processRunner.setEnvironment(environment);
     processRunner.run(command.toArray(new String[command.size()]));
 
     // wait for start if configured

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer.java
@@ -23,6 +23,8 @@ import com.google.cloud.tools.appengine.api.devserver.StopConfiguration;
 import com.google.cloud.tools.appengine.cloudsdk.internal.args.DevAppServerArgs;
 import com.google.cloud.tools.appengine.cloudsdk.internal.process.ProcessRunnerException;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,6 +32,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Cloud SDK based implementation of {@link AppEngineDevServer}.
@@ -61,6 +64,11 @@ public class CloudSdkAppEngineDevServer implements AppEngineDevServer {
       arguments.add(appYaml.toPath().toString());
     }
 
+    Map<String,String> env = Maps.newHashMap();
+    if (!Strings.isNullOrEmpty(config.getJavaHomeDir())) {
+      env.put("JAVA_HOME", config.getJavaHomeDir());
+    }
+
     arguments.addAll(DevAppServerArgs.get("host", config.getHost()));
     arguments.addAll(DevAppServerArgs.get("port", config.getPort()));
     arguments.addAll(DevAppServerArgs.get("admin_host", config.getAdminHost()));
@@ -88,7 +96,7 @@ public class CloudSdkAppEngineDevServer implements AppEngineDevServer {
         .addAll(DevAppServerArgs.get("default_gcs_bucket_name", config.getDefaultGcsBucketName()));
 
     try {
-      sdk.runDevAppServerCommand(arguments);
+      sdk.runDevAppServerCommand(arguments, env);
     } catch (ProcessRunnerException e) {
       throw new AppEngineException(e);
     }

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServerTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServerTest.java
@@ -20,15 +20,19 @@ import com.google.cloud.tools.appengine.api.AppEngineException;
 import com.google.cloud.tools.appengine.api.devserver.DefaultRunConfiguration;
 import com.google.cloud.tools.appengine.cloudsdk.internal.process.ProcessRunnerException;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
@@ -76,6 +80,7 @@ public class CloudSdkAppEngineDevServerTest {
     configuration.setDevAppserverLogLevel("info");
     configuration.setSkipSdkUpdateCheck(true);
     configuration.setDefaultGcsBucketName("buckets");
+    configuration.setJavaHomeDir("/usr/lib/jvm/default-java");
 
     List<String> expected = ImmutableList
         .of("app.yaml", "--host=host", "--port=8090", "--admin_host=adminHost",
@@ -87,9 +92,11 @@ public class CloudSdkAppEngineDevServerTest {
             "--api_port=8091", "--automatic_restart", "--dev_appserver_log_level=info",
             "--skip_sdk_update_check", "--default_gcs_bucket_name=buckets");
 
+    Map<String,String> expectedEnv = ImmutableMap.of("JAVA_HOME", "/usr/lib/jvm/default-java");
+
     devServer.run(configuration);
 
-    verify(sdk, times(1)).runDevAppServerCommand(eq(expected));
+    verify(sdk, times(1)).runDevAppServerCommand(eq(expected), eq(expectedEnv));
   }
 
   public void testPrepareCommand_booleanFlags() throws AppEngineException, ProcessRunnerException {
@@ -115,10 +122,11 @@ public class CloudSdkAppEngineDevServerTest {
     configuration.setAppYamls(ImmutableList.of(new File("app.yaml")));
 
     List<String> expected = ImmutableList.of("app.yaml");
+    Map<String,String> expectedEnv = ImmutableMap.of();
 
     devServer.run(configuration);
 
-    verify(sdk, times(1)).runDevAppServerCommand(eq(expected));
+    verify(sdk, times(1)).runDevAppServerCommand(eq(expected), eq(expectedEnv));
   }
 
 }


### PR DESCRIPTION
This was motivated by https://github.com/GoogleCloudPlatform/google-cloud-intellij/issues/927. These changes allow callers to specify a java_home directory in the devserver `RunConfiguration`. 

Note that up until now, RunConfiguration has been used to only specify arguments to `dev_appserver.py`. This change would be the first environment variable that is added to the RunConfiguration interface - I think it's kind of nice to abstract that from the user a bit; I'm interested to hear other thoughts on that.