### PR TITLE
Bump maven snapshot version to 0.1.12-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>appengine-plugins-core</artifactId>
-  <version>0.1.11-SNAPSHOT</version>
+  <version>0.1.12-SNAPSHOT</version>
 
   <name>App Engine Plugins Core Library</name>
   <description>


### PR DESCRIPTION
Since https://github.com/GoogleCloudPlatform/appengine-plugins-core/releases/tag/v0.1.11 has just been released.