### PR TITLE
update dependency scopes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -92,6 +93,7 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.1</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
@meltsufin @patflynn @elharo 

I think we had misconfigured some scopes earlier.
I'm pretty sure about the junit scope change
findbugs to provided seems to be what the internet [says](http://stackoverflow.com/questions/26867614/what-is-correct-maven-scope-of-findbugs-annotations) is needed, however this I'm a lot less sure about. Findbugs annotation are only at compile time right, they're not preserved into runtime?