### PR TITLE
Add environment variable on Windows to set file upload processes to 1

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -148,6 +148,12 @@ public class CloudSdk {
     if (appCommandMetricsEnvironmentVersion != null) {
       environment.put("CLOUDSDK_METRICS_ENVIRONMENT_VERSION", appCommandMetricsEnvironmentVersion);
     }
+    // This is to ensure IDE credentials get correctly passed to the gcloud commands, in Windows.
+    // It's a temporary workaround until a fix is released in b/31683722.
+    // https://github.com/GoogleCloudPlatform/google-cloud-intellij/issues/985
+    if (System.getProperty("os.name").contains("Windows")) {
+      environment.put("CLOUDSDK_APP_NUM_FILE_UPLOAD_PROCESSES", "1");
+    }
     logCommand(command);
     processRunner.setEnvironment(environment);
     processRunner.run(command.toArray(new String[command.size()]));

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -149,7 +149,7 @@ public class CloudSdk {
       environment.put("CLOUDSDK_METRICS_ENVIRONMENT_VERSION", appCommandMetricsEnvironmentVersion);
     }
     // This is to ensure IDE credentials get correctly passed to the gcloud commands, in Windows.
-    // It's a temporary workaround until a fix is released in b/31683722.
+    // It's a temporary workaround until a fix is released.
     // https://github.com/GoogleCloudPlatform/google-cloud-intellij/issues/985
     if (System.getProperty("os.name").contains("Windows")) {
       environment.put("CLOUDSDK_APP_NUM_FILE_UPLOAD_PROCESSES", "1");


### PR DESCRIPTION
This is to fix https://github.com/GoogleCloudPlatform/google-cloud-intellij/issues/985 while the definite fix isn't in place.