### PR TITLE
Ignore suffixes

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
@@ -115,12 +115,14 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
     }
   }
 
+  // TODO(alexsloan): implement and assert true semver comparisons, such that prerelease suffixes
+  // are compared according to the semver spec (semver.org)
   private List<Integer> parseVersionComponents(String version) throws NumberFormatException {
     // just strip out any suffixes
     version = ignoreBuildOrPrereleaseSuffix(version);
 
     String[] components = version.split("\\.");
-    ImmutableList.Builder builder = ImmutableList.builder();
+    ImmutableList.Builder<Integer> builder = ImmutableList.builder();
     for (String num : components) {
       builder.add(Integer.parseInt(num));
     }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
@@ -45,9 +45,9 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
   /**
    * Constructs a CloudSdkVersion from a version string.
    * @param version a non-null, nonempty string of the form "\d+(\.\d+)*[+-].*".
-   * @throws NumberFormatException if the string cannot be parsed
+   * @throws IllegalArgumentException if the string cannot be parsed
    */
-  public CloudSdkVersion(String version) throws NumberFormatException {
+  public CloudSdkVersion(String version) throws IllegalArgumentException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(version));
 
     this.version = version;
@@ -117,7 +117,7 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
 
   private List<Integer> parseVersionComponents(String version) throws NumberFormatException {
     // just strip out any suffixes
-    version = removeSuffix(version);
+    version = ignoreBuildOrPrereleaseSuffix(version);
 
     String[] components = version.split("\\.");
     ImmutableList.Builder builder = ImmutableList.builder();
@@ -127,7 +127,10 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
     return builder.build();
   }
 
-  private String removeSuffix(String version) {
+  // Returns the version string without its prerelease and/or build suffix. Any characters following
+  // (and including) the first occurrence of either the BUILD_SEPARATOR or the PRERELEASE_SEPARATOR
+  // will be ignored
+  private String ignoreBuildOrPrereleaseSuffix(String version) {
     List<Character> separators = ImmutableList.of(BUILD_SEPARATOR, PRERELEASE_SEPARATOR);
     for (int i = 0; i < version.length(); i++) {
       if (separators.contains(version.charAt(i))) {

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
@@ -19,12 +19,10 @@ package com.google.cloud.tools.appengine.cloudsdk.serialization;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.regex.Pattern;
 
 /**
  * Represents the version of the Cloud SDK. Loosely follows the semantic versioning spec

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
@@ -58,11 +58,6 @@ public class CloudSdkVersionTest {
     assertEquals(invalids.size(), thrown);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testConstructor_() {
-    new CloudSdkVersion("v1beta3-1.0.0");
-  }
-
   @Test
   public void testToString() {
     String version = "0.1.0.22";

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.appengine.cloudsdk.serialization;
 
+import com.google.common.collect.ImmutableList;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -42,8 +44,22 @@ public class CloudSdkVersionTest {
     new CloudSdkVersion("");
   }
 
-  @Test(expected = NumberFormatException.class)
-  public void testConstructor_nonNumeric() {
+  @Test
+  public void testConstructor_invalid() {
+    List<String> invalids = ImmutableList.of("v1beta3-1.0.0", "132.alpha-1.0", "132alpha-1.0");
+    int thrown = 0;
+    for (String invalid : invalids) {
+      try {
+        new CloudSdkVersion(invalid);
+      } catch (IllegalArgumentException exception) {
+        thrown++;
+      }
+    }
+    assertEquals(invalids.size(), thrown);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConstructor_() {
     new CloudSdkVersion("v1beta3-1.0.0");
   }
 

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -56,6 +57,18 @@ public class CloudSdkVersionTest {
   public void testEquals_differentSizes() {
     assertTrue(new CloudSdkVersion("0.1.0").equals(new CloudSdkVersion("0.1")));
     assertTrue(new CloudSdkVersion("0").equals(new CloudSdkVersion("0.0.0.0")));
+    assertFalse(new CloudSdkVersion("1.1").equals(new CloudSdkVersion("1.10")));
+  }
+
+  @Test
+  public void testEquals_preRelease() {
+    // TODO(alexsloan): implement and assert true semver comparisons, such that prerelease suffixes
+    // are compared according to the semver spec (semver.org)
+    assertEquals(new CloudSdkVersion("0.1.0-rc.1"), new CloudSdkVersion("0.1.0-rc.1"));
+    assertEquals(new CloudSdkVersion("0.1.0-rc.1"),
+        new CloudSdkVersion("0.1.0-release-anystring.x.y.z"));
+    assertEquals(new CloudSdkVersion("0.1.0+12345678-beta.1"),
+        new CloudSdkVersion("0.1.0-something"));
   }
 
   @Test
@@ -94,6 +107,13 @@ public class CloudSdkVersionTest {
     assertEquals(0, first.compareTo(second));
     assertEquals(firstVersion, first.toString());
     assertEquals(secondVersion, second.toString());
+  }
 
+  @Test
+  public void testCompareTo_preRelease() {
+    assertEquals(-1, new CloudSdkVersion("1.1.0-alpha-01")
+        .compareTo(new CloudSdkVersion("2.1.0-beta2+123456")));
+    assertEquals(-1, new CloudSdkVersion("1.1.0-01-asdf-beta")
+        .compareTo(new CloudSdkVersion("2.1.0-beta2+123456")));
   }
 }


### PR DESCRIPTION
quick followup to https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/242

According to the Cloud SDK team, the cloud sdk version follows semantic versioning (see semver.org). This change is necessary so that parsing doesn't break if a pre-release version string is used, e.g. `0.1.0-rc1`.  

Note that with this change, any version suffix is simply ignored for comparison purposes. Full semver parsing and comparison will be implemented later.