### PR TITLE
Set organization details

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,11 @@
   </description>
   <url>https://github.com/GoogleCloudPlatform/appengine-plugins-core/</url>
 
+  <organization>
+    <name>Google Inc.</name>
+    <url>http://www.google.com</url>
+  </organization>
+
   <licenses>
     <license>
       <name>The Apache License, Version 2.0</name>


### PR DESCRIPTION
maven-bundle-plugin turns `${pom.organization.name}` &rarr; `Bundle-Vendor` ([source](http://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html#default-behavior))

Fixes #253