### PR TITLE
Wait for output handlers and fix asyncRun() code

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/internal/process/DefaultProcessRunner.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/internal/process/DefaultProcessRunner.java
@@ -183,6 +183,7 @@ public class DefaultProcessRunner implements ProcessRunner {
 
   private void syncRun(Process process, Thread stdOutThread, Thread stdErrThread)
       throws InterruptedException {
+    int exitCode = process.waitFor();
     // https://github.com/GoogleCloudPlatform/appengine-plugins-core/issues/269
     if (stdOutThread != null) {
       stdOutThread.join();
@@ -191,7 +192,6 @@ public class DefaultProcessRunner implements ProcessRunner {
       stdErrThread.join();
     }
 
-    int exitCode = process.waitFor();
     for (ProcessExitListener exitListener : exitListeners) {
       exitListener.onExit(exitCode);
     }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/internal/process/DefaultProcessRunner.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/internal/process/DefaultProcessRunner.java
@@ -198,7 +198,7 @@ public class DefaultProcessRunner implements ProcessRunner {
   }
 
   private void asyncRun(final Process process,
-      final Thread stdOutHandler, final Thread stdErrHandler) throws InterruptedException {
+      final Thread stdOutHandler, final Thread stdErrHandler) {
     if (!exitListeners.isEmpty()
         || !stdOutLineListeners.isEmpty() || !stdErrLineListeners.isEmpty()) {
       Thread exitThread = new Thread("wait-for-process-exit-and-output-handlers") {


### PR DESCRIPTION
Fixes #269.
Fixes #266.

It will be much much easier to understand the PR if you look at the changes incrementally made by the two commits: https://github.com/GoogleCloudPlatform/appengine-plugins-core/commit/374d4677cdff11fc770244574e25df4f6b971e56, https://github.com/GoogleCloudPlatform/appengine-plugins-core/commit/53b48c5f6b72b6c1cde9d09856b3d18b89e2b8c9

The first commit https://github.com/GoogleCloudPlatform/appengine-plugins-core/commit/374d4677cdff11fc770244574e25df4f6b971e56 joins the output handlers for `syncRun()`. As discussed in #269, the output handlers will be able to consume all (buffered) output of the sub-process until EOF and eventually die gracefully, [*even if the handlers start running well after the sub-process dies*](https://github.com/GoogleCloudPlatform/appengine-plugins-core/issues/269#issuecomment-264614059) at least for small output. (I think it will also work for excessively large output, as long as the handlers keep consuming output, according to the [`Process` javadoc](https://docs.oracle.com/javase/7/docs/api/java/lang/Process.html):)

> Because some native platforms only provide limited buffer size for standard input and output streams, failure to promptly write the input stream or read the output stream of the subprocess may cause the subprocess to block, or even deadlock.

(As a side note, because we join the output handlers and ensure that access to the string built by the stdout handler happens only after the handler terminates, I believe the thread-safety fix in #270 is not really necessary. However, it's good to have the fix there.)

The second commit https://github.com/GoogleCloudPlatform/appengine-plugins-core/commit/53b48c5f6b72b6c1cde9d09856b3d18b89e2b8c9 fixes both #266 and #269 for `asyncRun()`, by actually invoking `syncRun()`.

I hope this fixes the issues, but there may be things that I am missing.