### PR TITLE
Bump version to 0.2.4-SNAPSHOT after 0.2.3 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>appengine-plugins-core</artifactId>
-  <version>0.2.2-SNAPSHOT</version>
+  <version>0.2.4-SNAPSHOT</version>
 
   <name>App Engine Plugins Core Library</name>
   <description>


### PR DESCRIPTION
Skipping 0.2.3-SNAPSHOT as we tagged two versions in a row (https://github.com/GoogleCloudPlatform/appengine-plugins-core/commit/2a09d26e06afefd9cdfa8b8174f4130637af70c7).