### PR TITLE
Improve CloudSdk.getVersion

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -287,10 +287,8 @@ public class CloudSdk {
     Path versionFile = getSdkPath().resolve(VERSION_FILE);
 
     if (!Files.isRegularFile(versionFile)) {
-      throw new CloudSdkOutOfDateException("Cloud SDK version is out of date. Please update to "
-          + "at least " + MINIMUM_VERSION, MINIMUM_VERSION);
+      throw new CloudSdkOutOfDateException(MINIMUM_VERSION);
     }
-    // TODO charset?
     List<String> lines = Files.readAllLines(versionFile, StandardCharsets.UTF_8);
     // expect only a single line
     String contents = lines.get(0);
@@ -298,8 +296,7 @@ public class CloudSdk {
     try {
       return new CloudSdkVersion(contents);
     } catch (IllegalArgumentException e) {
-      throw new CloudSdkOutOfDateException("Cloud SDK version is out of date. Please update to "
-          + "at least " + MINIMUM_VERSION, MINIMUM_VERSION);
+      throw new CloudSdkOutOfDateException(MINIMUM_VERSION);
     }
   }
 
@@ -391,12 +388,11 @@ public class CloudSdk {
     validateCloudSdkVersion();
   }
 
-  private void validateCloudSdkVersion() {
+  private void validateCloudSdkVersion() throws CloudSdkOutOfDateException {
     try {
       CloudSdkVersion version = getVersion();
       if (version.compareTo(MINIMUM_VERSION) < 0) {
-        throw new CloudSdkOutOfDateException("Cloud SDK version " + version
-            + " is too old. Please update to at least " + MINIMUM_VERSION, MINIMUM_VERSION);
+        throw new CloudSdkOutOfDateException(MINIMUM_VERSION);
       }
     } catch (IllegalArgumentException | IOException ex) {
       throw new CloudSdkNotFoundException("Could not determine Cloud SDK version", ex);

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -59,7 +59,9 @@ import javax.annotation.Nullable;
  * Cloud SDK CLI wrapper.
  */
 public class CloudSdk {
-  private static final CloudSdkVersion MINIMUM_VERSION = new CloudSdkVersion("133.0.0");
+
+  public static final CloudSdkVersion MINIMUM_VERSION = new CloudSdkVersion("133.0.0");
+
   private static final Logger logger = Logger.getLogger(CloudSdk.class.toString());
   private static final Joiner WHITESPACE_JOINER = Joiner.on(" ");
 

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -279,9 +279,12 @@ public class CloudSdk {
   }
 
   /**
-   * Returns the version of the Cloud SDK installation.
+   * Returns the version of the Cloud SDK installation. Version is determined by reading the VERSION
+   * file located in the Cloud SDK directory.
    *
    * @throws CloudSdkOutOfDateException if the Cloud SDK is too out of date to determine its version
+   * @throws IOException if the VERSION file could not be read. This might mean the Cloud SDK
+   *                     installation is corrupted.
    */
   public CloudSdkVersion getVersion() throws IOException {
     Path versionFile = getSdkPath().resolve(VERSION_FILE);
@@ -289,14 +292,18 @@ public class CloudSdk {
     if (!Files.isRegularFile(versionFile)) {
       throw new CloudSdkOutOfDateException(MINIMUM_VERSION);
     }
+
+    String contents = "";
     List<String> lines = Files.readAllLines(versionFile, StandardCharsets.UTF_8);
-    // expect only a single line
-    String contents = lines.get(0);
+    if (lines.size() > 0) {
+      // expect only a single line
+      contents = lines.get(0);
+    }
 
     try {
       return new CloudSdkVersion(contents);
     } catch (IllegalArgumentException e) {
-      throw new CloudSdkOutOfDateException(MINIMUM_VERSION);
+      throw new CloudSdkOutOfDateException(MINIMUM_VERSION, e);
     }
   }
 

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -394,7 +394,7 @@ public class CloudSdk {
   private void validateCloudSdkVersion() {
     try {
       CloudSdkVersion version = getVersion();
-      if (version.compareTo(MINIMUM_VERSION) <= 0) {
+      if (version.compareTo(MINIMUM_VERSION) < 0) {
         throw new CloudSdkOutOfDateException("Cloud SDK version " + version
             + " is too old. Please update to at least " + MINIMUM_VERSION, MINIMUM_VERSION);
       }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkOutOfDateException.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkOutOfDateException.java
@@ -16,13 +16,23 @@
 
 package com.google.cloud.tools.appengine.cloudsdk;
 
-/**
- * The Cloud SDK that was found is too old (generally before 131.0).
- */
-public class CloudSdkOutOfDateException extends CloudSdkNotFoundException {
+import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.appengine.cloudsdk.serialization.CloudSdkVersion;
 
-  public CloudSdkOutOfDateException(String message) {
+/**
+ * The Cloud SDK that was found is too old (generally before 133.0.0).
+ */
+public class CloudSdkOutOfDateException extends AppEngineException {
+
+  private CloudSdkVersion requiredVersion;
+
+  public CloudSdkOutOfDateException(String message, CloudSdkVersion requiredVersion) {
     super(message);
+    this.requiredVersion = requiredVersion;
+  }
+
+  public CloudSdkVersion getRequiredVersion() {
+    return requiredVersion;
   }
 
 }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkOutOfDateException.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkOutOfDateException.java
@@ -24,10 +24,13 @@ import com.google.cloud.tools.appengine.cloudsdk.serialization.CloudSdkVersion;
  */
 public class CloudSdkOutOfDateException extends AppEngineException {
 
+  private static final String MESSAGE
+      = "Cloud SDK versions below %s are not supported by this library.";
+
   private CloudSdkVersion requiredVersion;
 
-  public CloudSdkOutOfDateException(String message, CloudSdkVersion requiredVersion) {
-    super(message);
+  public CloudSdkOutOfDateException(CloudSdkVersion requiredVersion) {
+    super(String.format(MESSAGE, requiredVersion.toString()));
     this.requiredVersion = requiredVersion;
   }
 

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkOutOfDateException.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkOutOfDateException.java
@@ -34,6 +34,11 @@ public class CloudSdkOutOfDateException extends AppEngineException {
     this.requiredVersion = requiredVersion;
   }
 
+  public CloudSdkOutOfDateException(CloudSdkVersion requiredVersion, Throwable cause) {
+    super(String.format(MESSAGE, requiredVersion.toString()), cause);
+    this.requiredVersion = requiredVersion;
+  }
+
   public CloudSdkVersion getRequiredVersion() {
     return requiredVersion;
   }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkOutOfDateException.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkOutOfDateException.java
@@ -27,7 +27,7 @@ public class CloudSdkOutOfDateException extends AppEngineException {
   private static final String MESSAGE
       = "Cloud SDK versions below %s are not supported by this library.";
 
-  private CloudSdkVersion requiredVersion;
+  private final CloudSdkVersion requiredVersion;
 
   public CloudSdkOutOfDateException(CloudSdkVersion requiredVersion) {
     super(String.format(MESSAGE, requiredVersion.toString()));

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkVersionFileNotFoundException.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkVersionFileNotFoundException.java
@@ -18,6 +18,9 @@ package com.google.cloud.tools.appengine.cloudsdk;
 
 import com.google.cloud.tools.appengine.api.AppEngineException;
 
+/**
+ * The Cloud SDK's version file could not be found where expected.
+ */
 public class CloudSdkVersionFileNotFoundException extends AppEngineException {
 
   public CloudSdkVersionFileNotFoundException(String message) {

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkVersionFileNotFoundException.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkVersionFileNotFoundException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.appengine.cloudsdk;
+
+import com.google.cloud.tools.appengine.api.AppEngineException;
+
+public class CloudSdkVersionFileNotFoundException extends AppEngineException {
+
+  public CloudSdkVersionFileNotFoundException(String message) {
+    super(message);
+  }
+
+  public CloudSdkVersionFileNotFoundException(Throwable cause) {
+    super(cause);
+  }
+
+  public CloudSdkVersionFileNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkTest.java
@@ -61,9 +61,9 @@ public class CloudSdkTest {
   public void testGetVersion_fileNotExists() throws IOException {
     try {
       builder.build().getVersion();
-    } catch (CloudSdkOutOfDateException e) {
-      assertEquals("Cloud SDK versions below " + CloudSdk.MINIMUM_VERSION
-          + " are not supported by this library.", e.getMessage());
+    } catch (CloudSdkVersionFileNotFoundException e) {
+      assertEquals("Cloud SDK version file not found at " + root.resolve("VERSION"),
+          e.getMessage());
       return;
     }
     fail();
@@ -71,12 +71,14 @@ public class CloudSdkTest {
 
   @Test
   public void testGetVersion_fileContentInvalid() throws IOException {
-    writeVersionFile("invalid format");
+    String fileContents = "this is not a valid version string";
+    writeVersionFile(fileContents);
     try {
       builder.build().getVersion();
-    } catch (CloudSdkOutOfDateException e) {
-      assertEquals("Cloud SDK versions below " + CloudSdk.MINIMUM_VERSION
-          + " are not supported by this library.", e.getMessage());
+    } catch (IllegalStateException e) {
+      assertEquals("Pattern found in the Cloud SDK version file could not be parsed: "
+          + fileContents, e.getMessage());
+
       return;
     }
     fail();

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkTest.java
@@ -1,23 +1,15 @@
 package com.google.cloud.tools.appengine.cloudsdk;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
-
-import com.google.cloud.tools.appengine.cloudsdk.CloudSdk.Builder;
-import com.google.cloud.tools.appengine.cloudsdk.internal.process.ProcessRunnerException;
 import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdk.Builder;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessOutputLineListener;
-import com.google.cloud.tools.appengine.cloudsdk.serialization.CloudSdkVersion;
 import com.google.common.io.Files;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.IOException;
@@ -26,6 +18,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link CloudSdk}.
@@ -59,15 +57,29 @@ public class CloudSdkTest {
     new CloudSdk.Builder().build().validateCloudSdk();
   }
 
-  @Test(expected = CloudSdkOutOfDateException.class)
+  @Test
   public void testGetVersion_fileNotExists() throws IOException {
-    builder.build().getVersion();
+    try {
+      builder.build().getVersion();
+    } catch (CloudSdkOutOfDateException e) {
+      assertEquals("Cloud SDK versions below " + CloudSdk.MINIMUM_VERSION
+          + " are not supported by this library.", e.getMessage());
+      return;
+    }
+    fail();
   }
 
-  @Test(expected = CloudSdkOutOfDateException.class)
+  @Test
   public void testGetVersion_fileContentInvalid() throws IOException {
     writeVersionFile("invalid format");
-    builder.build().getVersion();
+    try {
+      builder.build().getVersion();
+    } catch (CloudSdkOutOfDateException e) {
+      assertEquals("Cloud SDK versions below " + CloudSdk.MINIMUM_VERSION
+          + " are not supported by this library.", e.getMessage());
+      return;
+    }
+    fail();
   }
 
   @Test


### PR DESCRIPTION
This PR makes a few enhancements to CloudSdk.getVersion that are required in order for the intellij plugin to use the version-compatibility logic in this library and not need to perform an expensive operation twice. (see https://github.com/GoogleCloudPlatform/google-cloud-intellij/issues/1127 for more context).

Quick summary of changes:
- Cloud SDK version is now determined by reading the VERSION file at the root of the cloud sdk installation, rather than calling gcloud in a subprocess. This is more performant and the code is less complex. Note that this means we can't determine the version of any cloud sdk installation that is earlier than 133.0.0 (when VERSION files first started being used)
- CloudSdkOutOfDateException no longer inherits from CloudSdkNotFoundException. This makes it a lot easier to validate based on these exceptions. 
- CloudSdkOutOfDateException now has the minimum required version as a member field. This allows clients of this library to construct their own validation messages using the data from the exception.

