### PR TITLE
Remove unnecessary exception catch

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/internal/process/DefaultProcessRunner.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/internal/process/DefaultProcessRunner.java
@@ -130,7 +130,7 @@ public class DefaultProcessRunner implements ProcessRunner {
         syncRun(process, stdOutHandler, stdErrHandler);
       }
 
-    } catch (IOException | InterruptedException | IllegalThreadStateException e) {
+    } catch (IOException | InterruptedException e) {
       throw new ProcessRunnerException(e);
     }
   }


### PR DESCRIPTION
[The only method that can throw `IllegalThreadStateException` is `exitValue()`.](https://docs.oracle.com/javase/7/docs/api/java/lang/Process.htm) We don't have `exitValue()`.

