### PR TITLE
Fix CloudSdkNotFoundException

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/PathResolver.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/PathResolver.java
@@ -50,6 +50,8 @@ public class PathResolver implements CloudSdkResolver {
     } else {
       // home directory
       possiblePaths.add(System.getProperty("user.home") + "/google-cloud-sdk");
+      // usr directory
+      possiblePaths.add("/usr");
       // try devshell VM
       possiblePaths.add("/google/google-cloud-sdk");
       // try bitnami Jenkins VM:

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/PathResolver.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/PathResolver.java
@@ -51,7 +51,7 @@ public class PathResolver implements CloudSdkResolver {
       // home directory
       possiblePaths.add(System.getProperty("user.home") + "/google-cloud-sdk");
       // usr directory
-      possiblePaths.add("/usr");
+      possiblePaths.add("/usr/lib/google-cloud-sdk");
       // try devshell VM
       possiblePaths.add("/google/google-cloud-sdk");
       // try bitnami Jenkins VM:


### PR DESCRIPTION
Update path resolver for look at /usr/bin directory. This patch fix CloudSdkNotFoundException related to official https://cloud.google.com/sdk/downloads Ubuntu/Debian apt-get install method. After installation, binaries are located at common /usr/bin/ directory.