### PR TITLE
Single exception for version file problems

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -288,9 +288,7 @@ public class CloudSdk {
    * Returns the version of the Cloud SDK installation. Version is determined by reading the VERSION
    * file located in the Cloud SDK directory.
    *
-   * @throws CloudSdkVersionFileNotFoundException if the VERSION file is not present
-   * @throws RuntimeException if there was an error reading the file
-   * @throws IllegalStateException if the file content could not be parsed
+   * @throws CloudSdkVersionFileNotFoundException if the VERSION file could not be read
    */
   public CloudSdkVersion getVersion() {
     Path versionFile = getSdkPath().resolve(VERSION_FILE_NAME);
@@ -308,11 +306,11 @@ public class CloudSdk {
         contents = lines.get(0);
       }
       return new CloudSdkVersion(contents);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    } catch (IllegalArgumentException e) {
-      throw new IllegalStateException(
-          "Pattern found in the Cloud SDK version file could not be parsed: " + contents, e);
+    } catch (IOException ex) {
+      throw new CloudSdkVersionFileNotFoundException(ex);
+    } catch (IllegalArgumentException ex) {
+      throw new CloudSdkVersionFileNotFoundException(
+          "Pattern found in the Cloud SDK version file could not be parsed: " + contents, ex);
     }
   }
 
@@ -339,7 +337,7 @@ public class CloudSdk {
     return CloudSdkComponent.fromJsonList(componentsJson);
   }
 
-  private void logCommand(List<String> command) {
+  private static void logCommand(List<String> command) {
     logger.info("submitting command: " + WHITESPACE_JOINER.join(command));
   }
 

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -288,13 +288,13 @@ public class CloudSdk {
    * Returns the version of the Cloud SDK installation. Version is determined by reading the VERSION
    * file located in the Cloud SDK directory.
    *
-   * @throws CloudSdkVersionFileNotFoundException if the VERSION file could not be read
+   * @throws CloudSdkVersionFileException if the VERSION file could not be read
    */
   public CloudSdkVersion getVersion() {
     Path versionFile = getSdkPath().resolve(VERSION_FILE_NAME);
 
     if (!Files.isRegularFile(versionFile)) {
-      throw new CloudSdkVersionFileNotFoundException("Cloud SDK version file not found at "
+      throw new CloudSdkVersionFileException("Cloud SDK version file not found at "
           + versionFile.toString());
     }
 
@@ -307,9 +307,9 @@ public class CloudSdk {
       }
       return new CloudSdkVersion(contents);
     } catch (IOException ex) {
-      throw new CloudSdkVersionFileNotFoundException(ex);
+      throw new CloudSdkVersionFileException(ex);
     } catch (IllegalArgumentException ex) {
-      throw new CloudSdkVersionFileNotFoundException(
+      throw new CloudSdkVersionFileException(
           "Pattern found in the Cloud SDK version file could not be parsed: " + contents, ex);
     }
   }
@@ -410,7 +410,7 @@ public class CloudSdk {
       if (version.compareTo(MINIMUM_VERSION) < 0) {
         throw new CloudSdkOutOfDateException(version, MINIMUM_VERSION);
       }
-    } catch (CloudSdkVersionFileNotFoundException ex) {
+    } catch (CloudSdkVersionFileException ex) {
       // this is a version of the Cloud SDK prior to when VERSION files were introduced
       throw new CloudSdkOutOfDateException(MINIMUM_VERSION);
     }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -296,7 +296,7 @@ public class CloudSdk {
     Path versionFile = getSdkPath().resolve(VERSION_FILE_NAME);
 
     if (!Files.isRegularFile(versionFile)) {
-      throw new CloudSdkVersionFileException("Cloud SDK version file not found at "
+      throw new CloudSdkVersionFileNotFoundException("Cloud SDK version file not found at "
           + versionFile.toString());
     }
 
@@ -311,7 +311,7 @@ public class CloudSdk {
     } catch (IOException ex) {
       throw new CloudSdkVersionFileException(ex);
     } catch (IllegalArgumentException ex) {
-      throw new CloudSdkVersionFileException(
+      throw new CloudSdkVersionFileParseException(
           "Pattern found in the Cloud SDK version file could not be parsed: " + contents, ex);
     }
   }
@@ -400,20 +400,23 @@ public class CloudSdk {
    *
    * @throws CloudSdkNotFoundException when Cloud SDK is not installed where expected
    * @throws CloudSdkOutOfDateException when Cloud SDK is out of date
+   * @throws CloudSdkVersionFileException VERSION file could not be read
    */
-  public void validateCloudSdk() throws CloudSdkNotFoundException, CloudSdkOutOfDateException {
+  public void validateCloudSdk()
+      throws CloudSdkNotFoundException, CloudSdkOutOfDateException, CloudSdkVersionFileException {
     validateCloudSdkLocation();
     validateCloudSdkVersion();
   }
 
-  private void validateCloudSdkVersion() throws CloudSdkOutOfDateException {
+  private void validateCloudSdkVersion() 
+      throws CloudSdkOutOfDateException, CloudSdkVersionFileException {
     try {
       CloudSdkVersion version = getVersion();
       if (version.compareTo(MINIMUM_VERSION) < 0) {
         throw new CloudSdkOutOfDateException(version, MINIMUM_VERSION);
       }
-    } catch (CloudSdkVersionFileException ex) {
-      // this is a version of the Cloud SDK prior to when VERSION files were introduced
+    } catch (CloudSdkVersionFileNotFoundException ex) {
+      // this is likely a version of the Cloud SDK prior to when VERSION files were introduced
       throw new CloudSdkOutOfDateException(MINIMUM_VERSION);
     }
   }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineVersions.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineVersions.java
@@ -32,10 +32,9 @@ import java.util.List;
  */
 public class CloudSdkAppEngineVersions implements AppEngineVersions {
 
-  private CloudSdk sdk;
+  private final CloudSdk sdk;
 
-  public CloudSdkAppEngineVersions(
-      CloudSdk sdk) {
+  public CloudSdkAppEngineVersions(CloudSdk sdk) {
     this.sdk = sdk;
   }
 
@@ -118,7 +117,8 @@ public class CloudSdkAppEngineVersions implements AppEngineVersions {
     execute(arguments);
   }
 
-  private List<String> commonVersionSelectionArgs(VersionsSelectionConfiguration configuration) {
+  private static List<String> commonVersionSelectionArgs(
+      VersionsSelectionConfiguration configuration) {
     List<String> arguments = new ArrayList<>();
     arguments.addAll(configuration.getVersions());
     arguments.addAll(GcloudArgs.get("service", configuration.getService()));

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkResolver.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkResolver.java
@@ -26,7 +26,7 @@ public interface CloudSdkResolver {
   /**
    * Attempts to find the path to Google Cloud SDK.
    *
-   * @return Path to Google Cloud SDK or null
+   * @return path to Google Cloud SDK or null
    */
   Path getCloudSdkPath();
 

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkVersionFileException.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkVersionFileException.java
@@ -19,19 +19,19 @@ package com.google.cloud.tools.appengine.cloudsdk;
 import com.google.cloud.tools.appengine.api.AppEngineException;
 
 /**
- * The Cloud SDK's version file could not be found where expected.
+ * The Cloud SDK's version file could not be read.
  */
-public class CloudSdkVersionFileNotFoundException extends AppEngineException {
+public class CloudSdkVersionFileException extends AppEngineException {
 
-  public CloudSdkVersionFileNotFoundException(String message) {
+  public CloudSdkVersionFileException(String message) {
     super(message);
   }
 
-  public CloudSdkVersionFileNotFoundException(Throwable cause) {
+  public CloudSdkVersionFileException(Throwable cause) {
     super(cause);
   }
 
-  public CloudSdkVersionFileNotFoundException(String message, Throwable cause) {
+  public CloudSdkVersionFileException(String message, Throwable cause) {
     super(message, cause);
   }
 }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkVersionFileNotFoundException.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkVersionFileNotFoundException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.appengine.cloudsdk;
+
+public class CloudSdkVersionFileNotFoundException extends CloudSdkVersionFileException {
+
+  public CloudSdkVersionFileNotFoundException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkVersionFileParseException.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkVersionFileParseException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.appengine.cloudsdk;
+
+public class CloudSdkVersionFileParseException extends CloudSdkVersionFileException {
+
+  public CloudSdkVersionFileParseException(String message, Throwable ex) {
+    super(message, ex);
+  }
+
+}

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.tools.appengine.cloudsdk;
 
 import com.google.cloud.tools.appengine.api.AppEngineException;
@@ -75,9 +91,9 @@ public class CloudSdkTest {
     writeVersionFile(fileContents);
     try {
       builder.build().getVersion();
-    } catch (IllegalStateException e) {
+    } catch (CloudSdkVersionFileNotFoundException ex) {
       assertEquals("Pattern found in the Cloud SDK version file could not be parsed: "
-          + fileContents, e.getMessage());
+          + fileContents, ex.getMessage());
 
       return;
     }

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkTest.java
@@ -77,7 +77,7 @@ public class CloudSdkTest {
   public void testGetVersion_fileNotExists() throws IOException {
     try {
       builder.build().getVersion();
-    } catch (CloudSdkVersionFileNotFoundException e) {
+    } catch (CloudSdkVersionFileException e) {
       assertEquals("Cloud SDK version file not found at " + root.resolve("VERSION"),
           e.getMessage());
       return;
@@ -91,7 +91,7 @@ public class CloudSdkTest {
     writeVersionFile(fileContents);
     try {
       builder.build().getVersion();
-    } catch (CloudSdkVersionFileNotFoundException ex) {
+    } catch (CloudSdkVersionFileException ex) {
       assertEquals("Pattern found in the Cloud SDK version file could not be parsed: "
           + fileContents, ex.getMessage());
 


### PR DESCRIPTION
@aslo @meltsufin Looking at this code for other reasons I realized that CT4E wasn't handling two of three possible failure modes because every mode has a different, unrelated, runtime exception type. The safest solution is to use  checked exceptions which would have turned our problems into compile time errors that were easily fixed. However as a stop gap use a single subclass of AppEngineException instead. 