### PR TITLE
Fix command-line generation for devappserver1

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
@@ -27,7 +27,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.common.io.ByteStreams;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -87,11 +86,13 @@ public class CloudSdkAppEngineDevServer1 implements AppEngineDevServer {
               .getAbsolutePath();
       jvmArguments.add("-javaagent:" + appengineAgentJar);
     } 
-    arguments.addAll(DevAppServerArgs.get("server", config.getHost()));
-    arguments.addAll(DevAppServerArgs.get("address", config.getPort()));
-    arguments.addAll(DevAppServerArgs.get("jvm_flag", config.getJvmFlags()));
+    arguments.addAll(DevAppServerArgs.get("address", config.getHost()));
+    arguments.addAll(DevAppServerArgs.get("port", config.getPort()));
+    if (config.getJvmFlags() != null) {
+      jvmArguments.addAll(config.getJvmFlags());
+    }
 
-    arguments.add("--allow_remote_shutdown");
+    // arguments.add("--allow_remote_shutdown");
     arguments.add("--disable_update_check");
     if (appengineWeb.isJava8()) {
       arguments.add("--no_java_agent");

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
@@ -92,7 +92,7 @@ public class CloudSdkAppEngineDevServer1 implements AppEngineDevServer {
       jvmArguments.addAll(config.getJvmFlags());
     }
 
-    // arguments.add("--allow_remote_shutdown");
+    arguments.add("--allow_remote_shutdown");
     arguments.add("--disable_update_check");
     if (appengineWeb.isJava8()) {
       arguments.add("--no_java_agent");

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1Test.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1Test.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.tools.appengine.cloudsdk;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.appengine.api.devserver.DefaultRunConfiguration;
+import com.google.cloud.tools.appengine.cloudsdk.internal.process.ProcessRunnerException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * Unit tests for {@link CloudSdkAppEngineDevServer}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CloudSdkAppEngineDevServer1Test {
+
+  @Mock
+  private CloudSdk sdk;
+
+  private CloudSdkAppEngineDevServer1 devServer;
+
+  private final File serviceDirectory = new File("src/test/java/resources");
+
+  @Before
+  public void setUp() {
+    devServer = new CloudSdkAppEngineDevServer1(sdk);
+  }
+
+  @Test
+  public void tesNullSdk() {
+    try {
+      new CloudSdkAppEngineDevServer1(null);
+      Assert.fail("Allowed null SDK");
+    } catch (NullPointerException expected) {
+    }
+  }
+
+  @Test
+  public void testPrepareCommand_allFlags() throws AppEngineException, ProcessRunnerException {
+
+    DefaultRunConfiguration configuration = new DefaultRunConfiguration();
+    configuration.setServices(ImmutableList.of(serviceDirectory));
+    configuration.setHost("host");
+    configuration.setPort(8090);
+    configuration.setJvmFlags(ImmutableList.of("-Dflag1", "-Dflag2"));
+    configuration.setRuntime("java");
+    configuration.setJavaHomeDir("/usr/lib/jvm/default-java");
+
+    List<String> expectedFlags = ImmutableList.of("--address=host", "--port=8090",
+        "--allow_remote_shutdown", "--disable_update_check", "--no_java_agent",
+        "src/test/java/resources");
+
+    Map<String, String> expectedEnv = ImmutableMap.of("JAVA_HOME", "/usr/lib/jvm/default-java");
+    List<String> expectedJvmArgs = ImmutableList.of("-Duse_jetty9_runtime=true",
+        "-D--enable_all_permissions=true", "-Dflag1", "-Dflag2");
+
+    devServer.run(configuration);
+
+    verify(sdk, times(1)).runDevAppServer1Command(eq(expectedJvmArgs), eq(expectedFlags), eq(expectedEnv));
+  }
+
+  @Test
+  public void testPrepareCommand_booleanFlags() throws AppEngineException, ProcessRunnerException {
+    DefaultRunConfiguration configuration = new DefaultRunConfiguration();
+
+    configuration.setServices(ImmutableList.of(serviceDirectory));
+
+    List<String> expectedFlags = ImmutableList.of("--allow_remote_shutdown",
+        "--disable_update_check", "--no_java_agent", "src/test/java/resources");
+    Map<String, String> expectedEnv = ImmutableMap.of();
+    List<String> expectedJvmArgs = ImmutableList.of("-Duse_jetty9_runtime=true",
+            "-D--enable_all_permissions=true");
+    devServer.run(configuration);
+    verify(sdk, times(1)).runDevAppServer1Command(eq(expectedJvmArgs), eq(expectedFlags), eq(expectedEnv));
+  }
+
+  @Test
+  public void testPrepareCommand_noFlags() throws AppEngineException, ProcessRunnerException {
+
+    DefaultRunConfiguration configuration = new DefaultRunConfiguration();
+    configuration.setServices(ImmutableList.of(serviceDirectory));
+
+    List<String> expectedFlags = ImmutableList.of("--allow_remote_shutdown",
+        "--disable_update_check", "--no_java_agent", "src/test/java/resources");
+    Map<String, String> expectedEnv = ImmutableMap.of();
+
+    List<String> expectedJvmArgs = ImmutableList.of("-Duse_jetty9_runtime=true",
+            "-D--enable_all_permissions=true");
+
+    devServer.run(configuration);
+
+    verify(sdk, times(1)).runDevAppServer1Command(eq(expectedJvmArgs), eq(expectedFlags), eq(expectedEnv));
+  }
+
+}


### PR DESCRIPTION
A few bug fixes uncovered when trying to get the devappserver1 to work with CT4E.
  - jvm flags need to be passed directly to the invoked JVM
  - `--allow_remote_shutdown` isn't supported in Cloud SDK 144.0
  - `--server` is to specify an update server; use `--address` and `--port`

PTAL @ludoch 