### PR TITLE
Quell M2Eclipse errors from use of error prone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,42 @@
         </executions>
       </plugin>
     </plugins>
+     
+    <pluginManagement>
+      <plugins>
+        <!-- m2eclipe does not support errorprone -->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <versionRange>[3.3,)</versionRange>
+                    <goals>
+                      <goal>compile</goal>
+                      <goal>testCompile</goal>
+                    </goals>
+                    <parameters>
+                      <compilerId>javac-with-errorprone</compilerId>
+                    </parameters>
+                  </pluginExecutionFilter>
+                  <action>
+                    <configurator>
+                      <id>org.eclipse.m2e.jdt.javaConfigurator</id>
+                    </configurator>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>    
+      </plugins>
+    </pluginManagement> 
   </build>
 
   <profiles>


### PR DESCRIPTION
M2Eclipse is unable to use `errorprone` and must continue to use the JDT compiler.