### PR TITLE
Rename devserver 2 classes to have "2"

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer2.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer2.java
@@ -35,14 +35,14 @@ import java.util.List;
 /**
  * Cloud SDK based implementation of {@link AppEngineDevServer}.
  */
-public class CloudSdkAppEngineDevServer implements AppEngineDevServer {
+public class CloudSdkAppEngineDevServer2 implements AppEngineDevServer {
 
   private final CloudSdk sdk;
 
   private static final String DEFAULT_ADMIN_HOST = "localhost";
   private static final int DEFAULT_ADMIN_PORT = 8000;
 
-  public CloudSdkAppEngineDevServer(CloudSdk sdk) {
+  public CloudSdkAppEngineDevServer2(CloudSdk sdk) {
     this.sdk = Preconditions.checkNotNull(sdk);
   }
 

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer2Test.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer2Test.java
@@ -41,27 +41,27 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
- * Unit tests for {@link CloudSdkAppEngineDevServer}.
+ * Unit tests for {@link CloudSdkAppEngineDevServer2}.
  */
 @RunWith(MockitoJUnitRunner.class)
-public class CloudSdkAppEngineDevServerTest {
+public class CloudSdkAppEngineDevServer2Test {
 
   @Mock
   private CloudSdk sdk;
   private Path fakeStoragePath = Paths.get("storage/path");
   private Path fakeDatastorePath = Paths.get("datastore/path");
 
-  private CloudSdkAppEngineDevServer devServer;
+  private CloudSdkAppEngineDevServer2 devServer;
 
   @Before
   public void setUp() {
-    devServer = new CloudSdkAppEngineDevServer(sdk);
+    devServer = new CloudSdkAppEngineDevServer2(sdk);
   }
   
   @Test
   public void tesNullSdk() {
     try {
-      new CloudSdkAppEngineDevServer(null);
+      new CloudSdkAppEngineDevServer2(null);
       Assert.fail("Allowed null SDK");
     } catch (NullPointerException expected) {
     }


### PR DESCRIPTION
As discussed in https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/381#discussion_r113278236

I think this makes things a bit clearer