### PR TITLE
Fix release

### DIFF
--- a/kokoro/release_sign.sh
+++ b/kokoro/release_sign.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Fail on any error.
+set -e
+# Display commands being run.
+set -x
+
+cd $KOKORO_GFILE_DIR
+mkdir signed && chmod 777 signed
+
+# find the latest directory under prod/appengine-plugins-core/gcp_ubuntu/release/
+LAST_BUILD=$(ls prod/appengine-plugins-core/gcp_ubuntu/release/ | sort -rV | head -1)
+
+# find the jars and the pom in the latest build artifact directory
+FILES=$(find `pwd`/prod/appengine-plugins-core/gcp_ubuntu/release/${LAST_BUILD}/* -type f \( -iname \*.jar -o -iname \*.pom \))
+
+for f in $FILES
+do
+  echo "Processing $f file..."
+  filename=$(basename "$f")
+  mv $f signed/$filename
+  if /escalated_sign/escalated_sign.py -j /escalated_sign_jobs -t linux_gpg_sign \
+    `pwd`/signed/$filename
+  then echo "Signed $filename"
+  else
+    echo "Could not sign $filename"
+    exit 1
+  fi
+done
+
+# bundle the artifacts for manual deploy to the Maven staging repository
+cd signed
+POM_NAME=$(ls *.pom)
+BUNDLE_NAME=${POM_NAME%.pom}-bundle.jar
+jar -cvf ${BUNDLE_NAME} *

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
           </execution>
         </executions>
       </plugin>
-      
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
@@ -247,7 +247,7 @@
         </executions>
       </plugin>
     </plugins>
-     
+
     <pluginManagement>
       <plugins>
         <!-- m2eclipe does not support errorprone -->
@@ -280,9 +280,9 @@
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>
-        </plugin>    
+        </plugin>
       </plugins>
-    </pluginManagement> 
+    </pluginManagement>
   </build>
 
   <profiles>
@@ -302,20 +302,6 @@
                 <id>attach-javadocs</id>
                 <goals>
                   <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
                 </goals>
               </execution>
             </executions>


### PR DESCRIPTION
build scripts need to be located in the repository
no need for the gpg plugin in the pom as we use Kokoro to sign the jars