### PR TITLE
Adds CloudSdk parameter for setting structured logs value

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -84,7 +84,8 @@ public class CloudSdk {
   private final String appCommandShowStructuredLogs;
   private final WaitingProcessOutputLineListener runDevAppServerWaitListener;
 
-  private CloudSdk(Path sdkPath, Path javaHomePath,
+  private CloudSdk(Path sdkPath,
+                   @Nullable Path javaHomePath,
                    @Nullable String appCommandMetricsEnvironment,
                    @Nullable String appCommandMetricsEnvironmentVersion,
                    @Nullable File appCommandCredentialFile,

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -181,7 +181,7 @@ public class CloudSdk {
       environment.put("CLOUDSDK_METRICS_ENVIRONMENT_VERSION", appCommandMetricsEnvironmentVersion);
     }
     if (appCommandShowStructuredLogs != null) {
-      environment.put("CLOUDSDK_SHOW_STRUCTURED_LOGS", appCommandShowStructuredLogs);
+      environment.put("CLOUDSDK_CORE_SHOW_STRUCTURED_LOGS", appCommandShowStructuredLogs);
     }
     // This is to ensure IDE credentials get correctly passed to the gcloud commands, in Windows.
     // It's a temporary workaround until a fix is released.

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -59,7 +59,7 @@ import javax.annotation.Nullable;
  */
 public class CloudSdk {
 
-  public static final CloudSdkVersion MINIMUM_VERSION = new CloudSdkVersion("145.0.0");
+  public static final CloudSdkVersion MINIMUM_VERSION = new CloudSdkVersion("159.0.0");
 
   private static final Logger logger = Logger.getLogger(CloudSdk.class.getName());
   private static final Joiner WHITESPACE_JOINER = Joiner.on(" ");

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -591,6 +591,10 @@ public class CloudSdk {
       return this;
     }
 
+    /**
+     * Sets structured json logs for the stderr output. Supported values include 'never' (default),
+     * 'always', 'terminal', etc.
+     */
     public Builder appCommandShowStructuredLogs(String appCommandShowStructuredLogs) {
       this.appCommandShowStructuredLogs = appCommandShowStructuredLogs;
       return this;

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -79,15 +79,18 @@ public class CloudSdk {
   private final ProcessRunner processRunner;
   private final String appCommandMetricsEnvironment;
   private final String appCommandMetricsEnvironmentVersion;
-  @Nullable
   private final File appCommandCredentialFile;
   private final String appCommandOutputFormat;
+  private final String appCommandShowStructuredLogs;
   private final WaitingProcessOutputLineListener runDevAppServerWaitListener;
 
-  private CloudSdk(Path sdkPath, Path javaHomePath, String appCommandMetricsEnvironment,
-                   String appCommandMetricsEnvironmentVersion,
+  private CloudSdk(Path sdkPath, Path javaHomePath,
+                   @Nullable String appCommandMetricsEnvironment,
+                   @Nullable String appCommandMetricsEnvironmentVersion,
                    @Nullable File appCommandCredentialFile,
-                   String appCommandOutputFormat, ProcessRunner processRunner,
+                   @Nullable String appCommandOutputFormat,
+                   @Nullable String appCommandShowStructuredLogs,
+                   ProcessRunner processRunner,
                    WaitingProcessOutputLineListener runDevAppServerWaitListener) {
     this.sdkPath = sdkPath;
     this.javaHomePath = javaHomePath;
@@ -95,6 +98,7 @@ public class CloudSdk {
     this.appCommandMetricsEnvironmentVersion = appCommandMetricsEnvironmentVersion;
     this.appCommandCredentialFile = appCommandCredentialFile;
     this.appCommandOutputFormat = appCommandOutputFormat;
+    this.appCommandShowStructuredLogs = appCommandShowStructuredLogs;
     this.processRunner = processRunner;
     this.runDevAppServerWaitListener = runDevAppServerWaitListener;
 
@@ -175,6 +179,9 @@ public class CloudSdk {
     }
     if (appCommandMetricsEnvironmentVersion != null) {
       environment.put("CLOUDSDK_METRICS_ENVIRONMENT_VERSION", appCommandMetricsEnvironmentVersion);
+    }
+    if (appCommandShowStructuredLogs != null) {
+      environment.put("CLOUDSDK_SHOW_STRUCTURED_LOGS", appCommandShowStructuredLogs);
     }
     // This is to ensure IDE credentials get correctly passed to the gcloud commands, in Windows.
     // It's a temporary workaround until a fix is released.
@@ -525,9 +532,9 @@ public class CloudSdk {
     private Path sdkPath;
     private String appCommandMetricsEnvironment;
     private String appCommandMetricsEnvironmentVersion;
-    @Nullable
     private File appCommandCredentialFile;
     private String appCommandOutputFormat;
+    private String appCommandShowStructuredLogs;
     private boolean async = false;
     private List<ProcessOutputLineListener> stdOutLineListeners = new ArrayList<>();
     private List<ProcessOutputLineListener> stdErrLineListeners = new ArrayList<>();
@@ -581,6 +588,11 @@ public class CloudSdk {
      */
     public Builder appCommandOutputFormat(String appCommandOutputFormat) {
       this.appCommandOutputFormat = appCommandOutputFormat;
+      return this;
+    }
+
+    public Builder appCommandShowStructuredLogs(String appCommandShowStructuredLogs) {
+      this.appCommandShowStructuredLogs = appCommandShowStructuredLogs;
       return this;
     }
 
@@ -713,7 +725,7 @@ public class CloudSdk {
 
       return new CloudSdk(sdkPath, javaHomePath, appCommandMetricsEnvironment,
           appCommandMetricsEnvironmentVersion, appCommandCredentialFile, appCommandOutputFormat,
-          processRunner, runDevAppServerWaitListener);
+          appCommandShowStructuredLogs, processRunner, runDevAppServerWaitListener);
     }
 
     /**

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -169,9 +169,20 @@ public class CloudSdk {
     command.addAll(args);
     command.addAll(GcloudArgs.get("format", appCommandOutputFormat));
 
-    Map<String, String> environment = Maps.newHashMap();
     if (appCommandCredentialFile != null) {
       command.addAll(GcloudArgs.get("credential-file-override", appCommandCredentialFile));
+    }
+
+    logCommand(command);
+    processRunner.setEnvironment(getGcloudCommandEnvironment());
+    processRunner.setWorkingDirectory(workingDirectory);
+    processRunner.run(command.toArray(new String[command.size()]));
+  }
+
+  @VisibleForTesting
+  Map<String, String> getGcloudCommandEnvironment() {
+    Map<String, String> environment = Maps.newHashMap();
+    if (appCommandCredentialFile != null) {
       environment.put("CLOUDSDK_APP_USE_GSUTIL", "0");
     }
     if (appCommandMetricsEnvironment != null) {
@@ -192,10 +203,7 @@ public class CloudSdk {
 
     environment.put("CLOUDSDK_CORE_DISABLE_PROMPTS", "1");
 
-    logCommand(command);
-    processRunner.setEnvironment(environment);
-    processRunner.setWorkingDirectory(workingDirectory);
-    processRunner.run(command.toArray(new String[command.size()]));
+    return environment;
   }
 
   // Runs a gcloud command synchronously, with a new ProcessRunner. This method is intended to be

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkTest.java
@@ -16,24 +16,6 @@
 
 package com.google.cloud.tools.appengine.cloudsdk;
 
-import com.google.cloud.tools.appengine.cloudsdk.CloudSdk.Builder;
-import com.google.cloud.tools.appengine.cloudsdk.process.ProcessOutputLineListener;
-import com.google.common.io.Files;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.List;
-
 import static org.hamcrest.core.AnyOf.anyOf;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringEndsWith.endsWith;
@@ -42,7 +24,26 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdk.Builder;
+import com.google.cloud.tools.appengine.cloudsdk.process.ProcessOutputLineListener;
+import com.google.common.io.Files;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Unit tests for {@link CloudSdk}.
@@ -238,5 +239,21 @@ public class CloudSdkTest {
     assertEquals(Paths.get("java", "path", "bin",
         System.getProperty("os.name").contains("Windows") ? "java.exe" : "java").toAbsolutePath(),
         sdk.getJavaExecutablePath());
+  }
+
+  @Test
+  public void testGcloudCommandEnvironment() {
+    builder.appCommandShowStructuredLogs("always");
+    builder.appCommandCredentialFile(mock(File.class));
+    builder.appCommandMetricsEnvironment("intellij");
+    builder.appCommandMetricsEnvironmentVersion("99");
+    CloudSdk sdk = builder.build();
+
+    Map<String, String> env = sdk.getGcloudCommandEnvironment();
+    assertEquals("0", env.get("CLOUDSDK_APP_USE_GSUTIL"));
+    assertEquals("always", env.get("CLOUDSDK_CORE_SHOW_STRUCTURED_LOGS"));
+    assertEquals("intellij", env.get("CLOUDSDK_METRICS_ENVIRONMENT"));
+    assertEquals("99", env.get("CLOUDSDK_METRICS_ENVIRONMENT_VERSION"));
+    assertEquals("1", env.get("CLOUDSDK_CORE_DISABLE_PROMPTS"));
   }
 }


### PR DESCRIPTION
fixes #425

This new parameter mimics the new gcloud configuration for providing the structured error logs environment variable setting `CLOUDSDK_CORE_SHOW_STRUCTURED_LOGS`.

gcloud accepts a string value for this: `terminal`, `log`, `always`, `never`

Setting this to terminal, or always, produces json output for messages coming from the cloudsdk according to the verbosity value currently set. 

**Example (consumed from IntelliJ):**

Without structured logs set (defaulted to `never`):
![image](https://user-images.githubusercontent.com/1735744/27392999-1ef85d58-5676-11e7-93c3-2046117a9ced.png)

Same error, with verbosity  defaulted to `error`, and the structure logs parameter set to `log`:
![image](https://user-images.githubusercontent.com/1735744/27392921-eb69f82a-5675-11e7-8b1b-f04faeecf093.png)

