### PR TITLE
Add gcloud JSON output de-serialization classes

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/JsonParseException.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/JsonParseException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.appengine.cloudsdk;
+
+public class JsonParseException extends Exception {
+
+  public JsonParseException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/JsonParseException.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/JsonParseException.java
@@ -16,6 +16,13 @@
 
 package com.google.cloud.tools.appengine.cloudsdk;
 
+/**
+ * Signals that there have been problems when parsing JSON input.
+ *
+ * <p>May signal general problems, including syntactic or semantic errors. However, the main reason
+ * that this exception was introduced in the library is to wrap the {@link
+ * com.google.gson.JsonSyntaxException} {@link RuntimeException} and make it a checked exception.
+ */
 public class JsonParseException extends Exception {
 
   public JsonParseException(Throwable cause) {

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResult.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResult.java
@@ -25,15 +25,16 @@ import java.util.List;
 /**
  * Holds de-serialized JSON result output of {@code gcloud app deploy}.
  */
-// Don't change the field names because Gson uses them for automatic de-serialization.
 public class AppEngineDeployResult {
 
   private static class Version {
-    String id;
-    String service;
-    String project;
+    // Don't change the field names because Gson uses them for automatic de-serialization.
+    private String id;
+    private String service;
+    private String project;
   }
 
+  // Don't change the field names because Gson uses them for automatic de-serialization.
   private List<Version> versions;
 
   private AppEngineDeployResult() {}  // empty private constructor
@@ -72,7 +73,8 @@ public class AppEngineDeployResult {
    * Parses a JSON string representing successful {@code gcloud app deploy} result.
    *
    * @return parsed JSON; never {@code null}
-   * @throws JsonParseException if {@code jsonString} has syntax errors or malformed JSON elements
+   * @throws JsonParseException if {@code jsonString} has syntax errors or incompatible JSON
+   *     element type
    */
   public static AppEngineDeployResult parse(String jsonString) throws JsonParseException {
     Preconditions.checkNotNull(jsonString);

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResult.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResult.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.appengine.cloudsdk.serialization;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+import java.util.List;
+
+/**
+ * Holds de-serialized JSON result output of {@code gcloud app deploy}.
+ */
+// Don't change the field names because Gson uses them for automatic de-serialization.
+public class AppEngineDeployResult {
+
+  private static class Version {
+    String id;
+    String service;
+    String project;
+  }
+
+  private List<Version> versions;
+
+  private AppEngineDeployResult() {}  // empty private constructor
+
+  /**
+   * Returns the version of the deployed app.
+   *
+   * @param index designates an app among multiple deployed apps
+   * @throws IndexOutOfBoundsException if the index is out of range
+   */
+  public String getVersion(int index) {
+    return versions.get(index).id;
+  }
+
+  /**
+   * Returns the service name of the deployed app.
+   *
+   * @param index designates an app among multiple deployed apps
+   * @throws IndexOutOfBoundsException if the index is out of range
+   */
+  public String getService(int index) {
+    return versions.get(index).service;
+  }
+
+  /**
+   * Returns the GCP project where the app is deployed.
+   *
+   * @param index designates an app among multiple deployed apps
+   * @throws IndexOutOfBoundsException if the index is out of range
+   */
+  public String getProject(int index) {
+    return versions.get(index).project;
+  }
+
+  /**
+   * Parses a JSON string representing successful {@code gcloud app deploy} result.
+   *
+   * @return parsed JSON; never {@code null}
+   * @throws JsonSyntaxException if {@code jsonString} has syntax errors
+   * @throws JsonParseException if {@code jsonString} has semantic errors (e.g., missing or empty
+   *     'versions' property)
+   */
+  public static AppEngineDeployResult parse(String jsonString) {
+    Preconditions.checkNotNull(jsonString);
+    AppEngineDeployResult json = new Gson().fromJson(jsonString, AppEngineDeployResult.class);
+    if (json == null || json.versions == null || json.versions.isEmpty()) {
+      throw new JsonParseException("cannot parse gcloud app deploy result output: " + jsonString);
+    }
+    for (Version version : json.versions) {
+      if (version.id == null || version.service == null || version.project == null) {
+        throw new JsonParseException("cannot parse gcloud app deploy result output: " + jsonString);
+      }
+    }
+    return json;
+  }
+}

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResult.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResult.java
@@ -16,9 +16,9 @@
 
 package com.google.cloud.tools.appengine.cloudsdk.serialization;
 
+import com.google.cloud.tools.appengine.cloudsdk.JsonParseException;
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
-import com.google.gson.JsonParseException;
 import com.google.gson.JsonSyntaxException;
 import java.util.List;
 
@@ -72,21 +72,14 @@ public class AppEngineDeployResult {
    * Parses a JSON string representing successful {@code gcloud app deploy} result.
    *
    * @return parsed JSON; never {@code null}
-   * @throws JsonSyntaxException if {@code jsonString} has syntax errors
-   * @throws JsonParseException if {@code jsonString} has semantic errors (e.g., missing or empty
-   *     'versions' property)
+   * @throws JsonParseException if {@code jsonString} has syntax errors or malformed JSON elements
    */
-  public static AppEngineDeployResult parse(String jsonString) {
+  public static AppEngineDeployResult parse(String jsonString) throws JsonParseException {
     Preconditions.checkNotNull(jsonString);
-    AppEngineDeployResult json = new Gson().fromJson(jsonString, AppEngineDeployResult.class);
-    if (json == null || json.versions == null || json.versions.isEmpty()) {
-      throw new JsonParseException("cannot parse gcloud app deploy result output: " + jsonString);
+    try {
+      return new Gson().fromJson(jsonString, AppEngineDeployResult.class);
+    } catch (JsonSyntaxException e) {
+      throw new JsonParseException(e);
     }
-    for (Version version : json.versions) {
-      if (version.id == null || version.service == null || version.project == null) {
-        throw new JsonParseException("cannot parse gcloud app deploy result output: " + jsonString);
-      }
-    }
-    return json;
   }
 }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLog.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLog.java
@@ -28,16 +28,48 @@ import com.google.gson.JsonSyntaxException;
 public class GcloudStructuredLog {
 
   public static class Error {
-    String type;
-    String stacktrace;
-    String details;
+    private String type;
+    private String stacktrace;
+    private String details;
+
+    public String getType() {
+      return type;
+    }
+
+    public String getStacktrace() {
+      return stacktrace;
+    }
+
+    public String getDetails() {
+      return details;
+    }
   }
 
-  public String version;
-  public String verbosity;
-  public String timestamp;
-  public String message;
-  public Error error;
+  private String version;
+  private String verbosity;
+  private String timestamp;
+  private String message;
+  private Error error;
+
+  public String getVersion() {
+    return version;
+  }
+
+  public String getVerbosity() {
+    return verbosity;
+  }
+
+  public String getTimestamp() {
+    return timestamp;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public Error getError() {
+    return error;
+  }
 
   private GcloudStructuredLog() {}  // empty private constructor
 

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLog.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLog.java
@@ -16,9 +16,9 @@
 
 package com.google.cloud.tools.appengine.cloudsdk.serialization;
 
+import com.google.cloud.tools.appengine.cloudsdk.JsonParseException;
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
-import com.google.gson.JsonParseException;
 import com.google.gson.JsonSyntaxException;
 
 /**
@@ -74,20 +74,17 @@ public class GcloudStructuredLog {
   private GcloudStructuredLog() {}  // empty private constructor
 
   /**
-   * Parses a JSON string representing gcloud structured log output.
+   * Parses a JSON string representing {@code gcloud} structured log output.
    *
    * @return parsed JSON; never {@code null}
-   * @throws JsonSyntaxException if {@code jsonString} has syntax errors
-   * @throws JsonParseException if {@code jsonString} has semantic errors
-   *     (e.g., missing 'timestamp' property)
+   * @throws JsonParseException if {@code jsonString} has syntax errors or malformed JSON elements
    */
-  public static GcloudStructuredLog parse(String jsonString) {
+  public static GcloudStructuredLog parse(String jsonString) throws JsonParseException {
     Preconditions.checkNotNull(jsonString);
-    GcloudStructuredLog json = new Gson().fromJson(jsonString, GcloudStructuredLog.class);
-    if (json.version == null || json.verbosity == null || json.timestamp == null
-        || json.message == null) {
-      throw new JsonParseException("cannot parse gcloud structured log entry: " + jsonString);
+    try {
+      return new Gson().fromJson(jsonString, GcloudStructuredLog.class);
+    } catch (JsonSyntaxException e) {
+      throw new JsonParseException(e);
     }
-    return json;
   }
 }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLog.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLog.java
@@ -24,10 +24,10 @@ import com.google.gson.JsonSyntaxException;
 /**
  * Holds de-serialized JSON of a single instance of structured log output from {@code gcloud}.
  */
-// Don't change the field names because Gson uses them for automatic de-serialization.
 public class GcloudStructuredLog {
 
   public static class Error {
+    // Don't change the field names because Gson uses them for automatic de-serialization.
     private String type;
     private String stacktrace;
     private String details;
@@ -45,6 +45,7 @@ public class GcloudStructuredLog {
     }
   }
 
+  // Don't change the field names because Gson uses them for automatic de-serialization.
   private String version;
   private String verbosity;
   private String timestamp;
@@ -77,7 +78,8 @@ public class GcloudStructuredLog {
    * Parses a JSON string representing {@code gcloud} structured log output.
    *
    * @return parsed JSON; never {@code null}
-   * @throws JsonParseException if {@code jsonString} has syntax errors or malformed JSON elements
+   * @throws JsonParseException if {@code jsonString} has syntax errors or incompatible JSON
+   *     element type
    */
   public static GcloudStructuredLog parse(String jsonString) throws JsonParseException {
     Preconditions.checkNotNull(jsonString);

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLog.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLog.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.appengine.cloudsdk.serialization;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+
+/**
+ * Holds de-serialized JSON of a single instance of structured log output from {@code gcloud}.
+ */
+// Don't change the field names because Gson uses them for automatic de-serialization.
+public class GcloudStructuredLog {
+
+  public static class Error {
+    String type;
+    String stacktrace;
+    String details;
+  }
+
+  public String version;
+  public String verbosity;
+  public String timestamp;
+  public String message;
+  public Error error;
+
+  private GcloudStructuredLog() {}  // empty private constructor
+
+  /**
+   * Parses a JSON string representing gcloud structured log output.
+   *
+   * @return parsed JSON; never {@code null}
+   * @throws JsonSyntaxException if {@code jsonString} has syntax errors
+   * @throws JsonParseException if {@code jsonString} has semantic errors
+   *     (e.g., missing 'timestamp' property)
+   */
+  public static GcloudStructuredLog parse(String jsonString) {
+    Preconditions.checkNotNull(jsonString);
+    GcloudStructuredLog json = new Gson().fromJson(jsonString, GcloudStructuredLog.class);
+    if (json.version == null || json.verbosity == null || json.timestamp == null
+        || json.message == null) {
+      throw new JsonParseException("cannot parse gcloud structured log entry: " + jsonString);
+    }
+    return json;
+  }
+}

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResultTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResultTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.appengine.cloudsdk.serialization;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AppEngineDeployResultTest {
+
+  private static final String ONE_VERSION =
+      "{" +
+      "  'configs': []," +
+      "  'versions': [" +
+      "    {" +
+      "      'id': '20160429t112518'," +
+      "      'last_deployed_time': null," +
+      "      'project': 'bizarre-project'," +
+      "      'service': 'display-service'," +
+      "      'traffic_split': null," +
+      "      'version': null" +
+      "    }" +
+      "  ]" +
+      "}";
+
+  private static final String TWO_VERSIONS =
+      "{" +
+      "  'configs': []," +
+      "  'versions': [" +
+      "    {" +
+      "      'id': '20160429t112518'," +
+      "      'last_deployed_time': null," +
+      "      'project': 'bizarre-project'," +
+      "      'service': 'display-service'," +
+      "      'traffic_split': null," +
+      "      'version': null" +
+      "    }," +
+      "    {" +
+      "      'id': '20170805t091353'," +
+      "      'last_deployed_time': null," +
+      "      'project': 'another-project'," +
+      "      'service': 'awesome-service'," +
+      "      'traffic_split': null," +
+      "      'version': null" +
+      "    }" +
+      "  ]" +
+      "}";
+
+  @Test
+  public void testParse_oneVersion() {
+    AppEngineDeployResult json = AppEngineDeployResult.parse(ONE_VERSION);
+    Assert.assertEquals("20160429t112518", json.getVersion(0));
+    Assert.assertEquals("display-service", json.getService(0));
+    Assert.assertEquals("bizarre-project", json.getProject(0));
+  }
+
+  @Test
+  public void testParse_twoVersions() {
+    AppEngineDeployResult json = AppEngineDeployResult.parse(TWO_VERSIONS);
+    Assert.assertEquals("20160429t112518", json.getVersion(0));
+    Assert.assertEquals("display-service", json.getService(0));
+    Assert.assertEquals("bizarre-project", json.getProject(0));
+
+    Assert.assertEquals("20170805t091353", json.getVersion(1));
+    Assert.assertEquals("awesome-service", json.getService(1));
+    Assert.assertEquals("another-project", json.getProject(1));
+  }
+
+  @Test
+  public void testParse_deprecatedFormat() {
+    String deprecatedFormat = "{ 'default': 'https://springboot-maven-project.appspot.com' }";
+    try {
+      AppEngineDeployResult.parse(deprecatedFormat);
+      fail();
+    } catch (JsonParseException e) {
+      assertThat(e.getMessage(), startsWith("cannot parse gcloud app deploy result output: "));
+    }
+  }
+
+  @Test
+  public void testParse_malformedInput() {
+    try {
+      AppEngineDeployResult.parse("non-JSON");
+      fail();
+    } catch (JsonSyntaxException e) {
+      assertNotNull(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testParse_nonArrayVersions() {
+    try {
+      AppEngineDeployResult.parse("{ 'versions' : 'non-array' }");
+      fail();
+    } catch (JsonSyntaxException e) {
+      assertNotNull(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testParse_versionsMissing() {
+    try {
+      AppEngineDeployResult.parse("{}");
+      fail();
+    } catch (JsonParseException e) {
+      assertThat(e.getMessage(), startsWith("cannot parse gcloud app deploy result output: "));
+    }
+  }
+
+  @Test
+  public void testParse_emptyVersions() {
+    try {
+      AppEngineDeployResult.parse("{ 'versions' : [] }");
+      fail();
+    } catch (JsonParseException e) {
+      assertThat(e.getMessage(), startsWith("cannot parse gcloud app deploy result output: "));
+    }
+  }
+
+  @Test
+  public void testParse_versionIdMissing() {
+    try {
+      AppEngineDeployResult.parse(
+          "{'versions': [ {'service': 'a-service', 'project': 'a-project'} ]}");
+      fail();
+    } catch (JsonParseException e) {
+      assertThat(e.getMessage(), startsWith("cannot parse gcloud app deploy result output: "));
+    }
+  }
+
+  @Test
+  public void testParse_versionServiceMissing() {
+    try {
+      AppEngineDeployResult.parse("{'versions': [ {'id': 'a-id', 'project': 'a-project'} ]}");
+      fail();
+    } catch (JsonParseException e) {
+      assertThat(e.getMessage(), startsWith("cannot parse gcloud app deploy result output: "));
+    }
+  }
+
+  @Test
+  public void testParse_versionProjectMissing() {
+    try {
+      AppEngineDeployResult.parse("{'versions': [ {'id': 'a-id', 'service': 'a-service'} ]}");
+      fail();
+    } catch (JsonParseException e) {
+      assertThat(e.getMessage(), startsWith("cannot parse gcloud app deploy result output: "));
+    }
+  }
+}

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResultTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResultTest.java
@@ -16,13 +16,10 @@
 
 package com.google.cloud.tools.appengine.cloudsdk.serialization;
 
-import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonSyntaxException;
+import com.google.cloud.tools.appengine.cloudsdk.JsonParseException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -67,7 +64,7 @@ public class AppEngineDeployResultTest {
       "}";
 
   @Test
-  public void testParse_oneVersion() {
+  public void testParse_oneVersion() throws JsonParseException {
     AppEngineDeployResult json = AppEngineDeployResult.parse(ONE_VERSION);
     Assert.assertEquals("20160429t112518", json.getVersion(0));
     Assert.assertEquals("display-service", json.getService(0));
@@ -75,7 +72,7 @@ public class AppEngineDeployResultTest {
   }
 
   @Test
-  public void testParse_twoVersions() {
+  public void testParse_twoVersions() throws JsonParseException {
     AppEngineDeployResult json = AppEngineDeployResult.parse(TWO_VERSIONS);
     Assert.assertEquals("20160429t112518", json.getVersion(0));
     Assert.assertEquals("display-service", json.getService(0));
@@ -87,22 +84,11 @@ public class AppEngineDeployResultTest {
   }
 
   @Test
-  public void testParse_deprecatedFormat() {
-    String deprecatedFormat = "{ 'default': 'https://springboot-maven-project.appspot.com' }";
-    try {
-      AppEngineDeployResult.parse(deprecatedFormat);
-      fail();
-    } catch (JsonParseException e) {
-      assertThat(e.getMessage(), startsWith("cannot parse gcloud app deploy result output: "));
-    }
-  }
-
-  @Test
   public void testParse_malformedInput() {
     try {
       AppEngineDeployResult.parse("non-JSON");
       fail();
-    } catch (JsonSyntaxException e) {
+    } catch (JsonParseException e) {
       assertNotNull(e.getMessage());
     }
   }
@@ -112,59 +98,34 @@ public class AppEngineDeployResultTest {
     try {
       AppEngineDeployResult.parse("{ 'versions' : 'non-array' }");
       fail();
-    } catch (JsonSyntaxException e) {
+    } catch (JsonParseException e) {
       assertNotNull(e.getMessage());
     }
   }
 
   @Test
-  public void testParse_versionsMissing() {
-    try {
-      AppEngineDeployResult.parse("{}");
-      fail();
-    } catch (JsonParseException e) {
-      assertThat(e.getMessage(), startsWith("cannot parse gcloud app deploy result output: "));
-    }
+  public void testParse_noErrorWhenVersionsMissing() throws JsonParseException {
+    AppEngineDeployResult.parse("{}");
   }
 
   @Test
-  public void testParse_emptyVersions() {
-    try {
-      AppEngineDeployResult.parse("{ 'versions' : [] }");
-      fail();
-    } catch (JsonParseException e) {
-      assertThat(e.getMessage(), startsWith("cannot parse gcloud app deploy result output: "));
-    }
+  public void testParse_noErrorWhenEmptyVersions() throws JsonParseException {
+    AppEngineDeployResult.parse("{ 'versions' : [] }");
   }
 
   @Test
-  public void testParse_versionIdMissing() {
-    try {
-      AppEngineDeployResult.parse(
-          "{'versions': [ {'service': 'a-service', 'project': 'a-project'} ]}");
-      fail();
-    } catch (JsonParseException e) {
-      assertThat(e.getMessage(), startsWith("cannot parse gcloud app deploy result output: "));
-    }
+  public void testParse_noErrorWhenVersionIdMissing() throws JsonParseException {
+    AppEngineDeployResult.parse(
+        "{'versions': [ {'service': 'a-service', 'project': 'a-project'} ]}");
   }
 
   @Test
-  public void testParse_versionServiceMissing() {
-    try {
-      AppEngineDeployResult.parse("{'versions': [ {'id': 'a-id', 'project': 'a-project'} ]}");
-      fail();
-    } catch (JsonParseException e) {
-      assertThat(e.getMessage(), startsWith("cannot parse gcloud app deploy result output: "));
-    }
+  public void testParse_noErrorWhenVersionServiceMissing() throws JsonParseException {
+    AppEngineDeployResult.parse("{'versions': [ {'id': 'a-id', 'project': 'a-project'} ]}");
   }
 
   @Test
-  public void testParse_versionProjectMissing() {
-    try {
-      AppEngineDeployResult.parse("{'versions': [ {'id': 'a-id', 'service': 'a-service'} ]}");
-      fail();
-    } catch (JsonParseException e) {
-      assertThat(e.getMessage(), startsWith("cannot parse gcloud app deploy result output: "));
-    }
+  public void testParse_noErrorWhenVersionProjectMissing() throws JsonParseException {
+    AppEngineDeployResult.parse("{'versions': [ {'id': 'a-id', 'service': 'a-service'} ]}");
   }
 }

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLogTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLogTest.java
@@ -16,15 +16,12 @@
 
 package com.google.cloud.tools.appengine.cloudsdk.serialization;
 
-import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonSyntaxException;
+import com.google.cloud.tools.appengine.cloudsdk.JsonParseException;
 import org.junit.Test;
 
 public class GcloudStructuredLogTest {
@@ -46,7 +43,7 @@ public class GcloudStructuredLogTest {
       + " 'message': '(gcloud.app.deploy) Could not copy [/tmp/tmpAqUB6m/src.tgz]' }";
 
   @Test
-  public void testParse_fullJson() {
+  public void testParse_fullJson() throws JsonParseException {
     GcloudStructuredLog log = GcloudStructuredLog.parse(sampleJson);
     assertEquals("semantic version of the message format, e.g. 0.0.1", log.getVersion());
     assertEquals("logging level: e.g. debug, info, warn, error, critical, exception",
@@ -61,7 +58,7 @@ public class GcloudStructuredLogTest {
   }
 
   @Test
-  public void testParse_errorNotPresent() {
+  public void testParse_errorNotPresent() throws JsonParseException {
     GcloudStructuredLog log = GcloudStructuredLog.parse(noErrorSampleJson);
     assertEquals("0.0.1", log.getVersion());
     assertEquals("ERROR", log.getVerbosity());
@@ -75,52 +72,32 @@ public class GcloudStructuredLogTest {
     try {
       GcloudStructuredLog.parse("non-JSON");
       fail();
-    } catch (JsonSyntaxException e) {
+    } catch (JsonParseException e) {
       assertNotNull(e.getMessage());
     }
   }
 
   @Test
-  public void testParse_versionMissing() {
-    try {
-      GcloudStructuredLog.parse(
-          "{'verbosity': 'INFO', 'timestamp': 'a-timestamp', 'message': 'info message'}");
-      fail();
-    } catch (JsonParseException e) {
-      assertThat(e.getMessage(), startsWith("cannot parse gcloud structured log entry: "));
-    }
+  public void testParse_noErrorWhenVersionMissing() throws JsonParseException {
+    GcloudStructuredLog.parse(
+        "{'verbosity': 'INFO', 'timestamp': 'a-timestamp', 'message': 'info message'}");
   }
 
   @Test
-  public void testParse_verbosityMissing() {
-    try {
-      GcloudStructuredLog.parse(
-          "{'version': '0.0.1', 'timestamp': 'a-timestamp', 'message': 'info message'}");
-      fail();
-    } catch (JsonParseException e) {
-      assertThat(e.getMessage(), startsWith("cannot parse gcloud structured log entry: "));
-    }
+  public void testParse_noErrorWhenVerbosityMissing() throws JsonParseException {
+    GcloudStructuredLog.parse(
+        "{'version': '0.0.1', 'timestamp': 'a-timestamp', 'message': 'info message'}");
   }
 
   @Test
-  public void testParse_timestampMissing() {
-    try {
-      GcloudStructuredLog.parse(
-          "{'version': '0.0.1', 'verbosity': 'INFO', 'message': 'info message'}");
-      fail();
-    } catch (JsonParseException e) {
-      assertThat(e.getMessage(), startsWith("cannot parse gcloud structured log entry: "));
-    }
+  public void testParse_noErrorWhenTimestampMissing() throws JsonParseException {
+    GcloudStructuredLog.parse(
+        "{'version': '0.0.1', 'verbosity': 'INFO', 'message': 'info message'}");
   }
 
   @Test
-  public void testParse_messageMissing() {
-    try {
-      GcloudStructuredLog.parse(
-          "{'version': '0.0.1', 'verbosity': 'INFO', 'timestamp': 'a-timestamp'}");
-      fail();
-    } catch (JsonParseException e) {
-      assertThat(e.getMessage(), startsWith("cannot parse gcloud structured log entry: "));
-    }
+  public void testParse_noErrorWhenMessageMissing() throws JsonParseException {
+    GcloudStructuredLog.parse(
+        "{'version': '0.0.1', 'verbosity': 'INFO', 'timestamp': 'a-timestamp'}");
   }
 }

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLogTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLogTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.appengine.cloudsdk.serialization;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+import org.junit.Test;
+
+public class GcloudStructuredLogTest {
+
+  private static final String sampleJson = "{"
+      + "  'version': 'semantic version of the message format, e.g. 0.0.1',"
+      + "  'verbosity': 'logging level: e.g. debug, info, warn, error, critical, exception',"
+      + "  'timestamp': 'time event logged in UTC log file format: %Y-%m-%dT%H:%M:%S.%3f%Ez',"
+      + "  'message': 'log/error message string',"
+      + "  'error': {"
+      + "    'type': 'exception or error raised (if logged message has actual exception data)',"
+      + "    'stacktrace': 'stacktrace or error if available',"
+      + "    'details': 'any additional error details'"
+      + "  }"
+      + "}";
+
+  private static final String noErrorSampleJson = "{ 'version': '0.0.1', 'verbosity': 'ERROR',"
+      + " 'timestamp': '2017-08-04T18:49:50.917Z',"
+      + " 'message': '(gcloud.app.deploy) Could not copy [/tmp/tmpAqUB6m/src.tgz]' }";
+
+  private static final String noVersionSampleJson = "{ 'verbosity': 'ERROR',"
+      + " 'timestamp': '2017-08-04T18:49:50.917Z',"
+      + " 'message': '(gcloud.app.deploy) Could not copy [/tmp/tmpAqUB6m/src.tgz]' }";
+
+  private static final String noVerbositySampleJson = "{ 'version': '0.0.1',"
+      + " 'timestamp': '2017-08-04T18:49:50.917Z',"
+      + " 'message': '(gcloud.app.deploy) Could not copy [/tmp/tmpAqUB6m/src.tgz]' }";
+
+  private static final String noTimestampSampleJson = "{ 'version': '0.0.1', 'verbosity': 'ERROR',"
+      + " 'message': '(gcloud.app.deploy) Could not copy [/tmp/tmpAqUB6m/src.tgz]' }";
+
+  private static final String noMessageSampleJson = "{ 'version': '0.0.1', 'verbosity': 'ERROR',"
+      + " 'timestamp': '2017-08-04T18:49:50.917Z' }";
+
+  @Test
+  public void testParse_fullJson() {
+    GcloudStructuredLog error = GcloudStructuredLog.parse(sampleJson);
+    assertEquals("semantic version of the message format, e.g. 0.0.1", error.version);
+    assertEquals("logging level: e.g. debug, info, warn, error, critical, exception",
+        error.verbosity);
+    assertEquals("time event logged in UTC log file format: %Y-%m-%dT%H:%M:%S.%3f%Ez",
+        error.timestamp);
+    assertEquals("log/error message string", error.message);
+    assertEquals("exception or error raised (if logged message has actual exception data)",
+        error.error.type);
+    assertEquals("stacktrace or error if available", error.error.stacktrace);
+    assertEquals("any additional error details", error.error.details);
+  }
+
+  @Test
+  public void testParse_errorNotPresent() {
+    GcloudStructuredLog error = GcloudStructuredLog.parse(noErrorSampleJson);
+    assertEquals("0.0.1", error.version);
+    assertEquals("ERROR", error.verbosity);
+    assertEquals("2017-08-04T18:49:50.917Z", error.timestamp);
+    assertEquals("(gcloud.app.deploy) Could not copy [/tmp/tmpAqUB6m/src.tgz]", error.message);
+    assertNull(error.error);
+  }
+
+  @Test
+  public void testParse_inputMalformed() {
+    try {
+      GcloudStructuredLog.parse("non-JSON");
+      fail();
+    } catch (JsonSyntaxException e) {
+      assertNotNull(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testParse_versionMissing() {
+    try {
+      GcloudStructuredLog.parse(
+          "{'verbosity': 'INFO', 'timestamp': 'a-timestamp', 'message': 'info message'}");
+      fail();
+    } catch (JsonParseException e) {
+      assertThat(e.getMessage(), startsWith("cannot parse gcloud structured log entry: "));
+    }
+  }
+
+  @Test
+  public void testParse_verbosityMissing() {
+    try {
+      GcloudStructuredLog.parse(
+          "{'version': '0.0.1', 'timestamp': 'a-timestamp', 'message': 'info message'}");
+      fail();
+    } catch (JsonParseException e) {
+      assertThat(e.getMessage(), startsWith("cannot parse gcloud structured log entry: "));
+    }
+  }
+
+  @Test
+  public void testParse_timestampMissing() {
+    try {
+      GcloudStructuredLog.parse(
+          "{'version': '0.0.1', 'verbosity': 'INFO', 'message': 'info message'}");
+      fail();
+    } catch (JsonParseException e) {
+      assertThat(e.getMessage(), startsWith("cannot parse gcloud structured log entry: "));
+    }
+  }
+
+  @Test
+  public void testParse_messageMissing() {
+    try {
+      GcloudStructuredLog.parse(
+          "{'version': '0.0.1', 'verbosity': 'INFO', 'timestamp': 'a-timestamp'}");
+      fail();
+    } catch (JsonParseException e) {
+      assertThat(e.getMessage(), startsWith("cannot parse gcloud structured log entry: "));
+    }
+  }
+}

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLogTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLogTest.java
@@ -45,43 +45,29 @@ public class GcloudStructuredLogTest {
       + " 'timestamp': '2017-08-04T18:49:50.917Z',"
       + " 'message': '(gcloud.app.deploy) Could not copy [/tmp/tmpAqUB6m/src.tgz]' }";
 
-  private static final String noVersionSampleJson = "{ 'verbosity': 'ERROR',"
-      + " 'timestamp': '2017-08-04T18:49:50.917Z',"
-      + " 'message': '(gcloud.app.deploy) Could not copy [/tmp/tmpAqUB6m/src.tgz]' }";
-
-  private static final String noVerbositySampleJson = "{ 'version': '0.0.1',"
-      + " 'timestamp': '2017-08-04T18:49:50.917Z',"
-      + " 'message': '(gcloud.app.deploy) Could not copy [/tmp/tmpAqUB6m/src.tgz]' }";
-
-  private static final String noTimestampSampleJson = "{ 'version': '0.0.1', 'verbosity': 'ERROR',"
-      + " 'message': '(gcloud.app.deploy) Could not copy [/tmp/tmpAqUB6m/src.tgz]' }";
-
-  private static final String noMessageSampleJson = "{ 'version': '0.0.1', 'verbosity': 'ERROR',"
-      + " 'timestamp': '2017-08-04T18:49:50.917Z' }";
-
   @Test
   public void testParse_fullJson() {
-    GcloudStructuredLog error = GcloudStructuredLog.parse(sampleJson);
-    assertEquals("semantic version of the message format, e.g. 0.0.1", error.version);
+    GcloudStructuredLog log = GcloudStructuredLog.parse(sampleJson);
+    assertEquals("semantic version of the message format, e.g. 0.0.1", log.getVersion());
     assertEquals("logging level: e.g. debug, info, warn, error, critical, exception",
-        error.verbosity);
+        log.getVerbosity());
     assertEquals("time event logged in UTC log file format: %Y-%m-%dT%H:%M:%S.%3f%Ez",
-        error.timestamp);
-    assertEquals("log/error message string", error.message);
+        log.getTimestamp());
+    assertEquals("log/error message string", log.getMessage());
     assertEquals("exception or error raised (if logged message has actual exception data)",
-        error.error.type);
-    assertEquals("stacktrace or error if available", error.error.stacktrace);
-    assertEquals("any additional error details", error.error.details);
+        log.getError().getType());
+    assertEquals("stacktrace or error if available", log.getError().getStacktrace());
+    assertEquals("any additional error details", log.getError().getDetails());
   }
 
   @Test
   public void testParse_errorNotPresent() {
-    GcloudStructuredLog error = GcloudStructuredLog.parse(noErrorSampleJson);
-    assertEquals("0.0.1", error.version);
-    assertEquals("ERROR", error.verbosity);
-    assertEquals("2017-08-04T18:49:50.917Z", error.timestamp);
-    assertEquals("(gcloud.app.deploy) Could not copy [/tmp/tmpAqUB6m/src.tgz]", error.message);
-    assertNull(error.error);
+    GcloudStructuredLog log = GcloudStructuredLog.parse(noErrorSampleJson);
+    assertEquals("0.0.1", log.getVersion());
+    assertEquals("ERROR", log.getVerbosity());
+    assertEquals("2017-08-04T18:49:50.917Z", log.getTimestamp());
+    assertEquals("(gcloud.app.deploy) Could not copy [/tmp/tmpAqUB6m/src.tgz]", log.getMessage());
+    assertNull(log.getError());
   }
 
   @Test


### PR DESCRIPTION
- `AppEngineDeployResult` for the `gcloud app deploy` stdout, which contains the info about deployed apps.
- `GcloudStructuredLog` for structured log entries from `gcloud`