### PR TITLE
Adds GAE_ENV and GAE_RUNTIME environment variables for local development.

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
@@ -110,7 +110,9 @@ public class CloudSdkAppEngineDevServer1 implements AppEngineDevServer {
       arguments.addAll(additionalArguments);
     }
 
-    if (isJava8(config.getServices())) {
+    boolean isJava8 = isJava8(config.getServices());
+
+    if (isJava8) {
       jvmArguments.add("-Duse_jetty9_runtime=true");
       jvmArguments.add("-D--enable_all_permissions=true");
       arguments.add("--no_java_agent");
@@ -131,7 +133,7 @@ public class CloudSdkAppEngineDevServer1 implements AppEngineDevServer {
           + Joiner.on(",").withKeyValueSeparator("=").join(appEngineEnvironment));
     }
 
-    String gaeRuntime = getGaeRuntimeJava(isJava8(config.getServices()));
+    String gaeRuntime = getGaeRuntimeJava(isJava8);
     appEngineEnvironment.putAll(getLocalAppEngineEnvironmentVariables(gaeRuntime));
 
     if (config.getEnvironment() != null) {

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
@@ -131,8 +131,8 @@ public class CloudSdkAppEngineDevServer1 implements AppEngineDevServer {
           + Joiner.on(",").withKeyValueSeparator("=").join(appEngineEnvironment));
     }
 
-    appEngineEnvironment.putAll(
-        getLocalAppEngineEnvironmentVariables(isJava8(config.getServices())));
+    String gaeRuntime = getGaeRuntime(isJava8(config.getServices()));
+    appEngineEnvironment.putAll(getLocalAppEngineEnvironmentVariables(gaeRuntime));
 
     if (config.getEnvironment() != null) {
       appEngineEnvironment.putAll(config.getEnvironment());
@@ -249,18 +249,26 @@ public class CloudSdkAppEngineDevServer1 implements AppEngineDevServer {
    * Gets a {@code Map<String, String>} of the environment variables for running the {@link
    * AppEngineDevServer}.
    *
-   * @param isJava8 if {@code true}, uses java8 as the GAE_RUNTIME; otherwise, uses java7
+   * @param gaeRuntime the runtime ID to set the environment variable GAE_RUNTIME to
    * @return {@code Map<String, String>} that maps from the environment variable name to its value
    */
-  private static Map<String, String> getLocalAppEngineEnvironmentVariables(boolean isJava8) {
+  private static Map<String, String> getLocalAppEngineEnvironmentVariables(String gaeRuntime) {
     Map<String, String> environment = Maps.newHashMap();
 
     String gaeEnv = "localdev";
-    String gaeRuntime = isJava8 ? "java8" : "java7";
     environment.put("GAE_ENV", gaeEnv);
     environment.put("GAE_RUNTIME", gaeRuntime);
 
     return environment;
+  }
+
+  /**
+   *
+   * @param isJava8 if {@code true}, use Java 8; otherwise, use Java 7
+   * @return "java8" if {@code isJava8} is true; otherwise, returns "java7"
+   */
+  private static String getGaeRuntime(boolean isJava8) {
+    return isJava8 ? "java8" : "java7";
   }
 
   private static void checkAndWarnDuplicateEnvironmentVariables(Map<String, String> newEnvironment,

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
@@ -254,7 +254,8 @@ public class CloudSdkAppEngineDevServer1 implements AppEngineDevServer {
    * @param gaeRuntime the runtime ID to set the environment variable GAE_RUNTIME to
    * @return {@code Map<String, String>} that maps from the environment variable name to its value
    */
-  private static Map<String, String> getLocalAppEngineEnvironmentVariables(String gaeRuntime) {
+  @VisibleForTesting
+  static Map<String, String> getLocalAppEngineEnvironmentVariables(String gaeRuntime) {
     Map<String, String> environment = Maps.newHashMap();
 
     String gaeEnv = "localdev";
@@ -269,7 +270,8 @@ public class CloudSdkAppEngineDevServer1 implements AppEngineDevServer {
    * @param isJava8 if {@code true}, use Java 8; otherwise, use Java 7
    * @return "java8" if {@code isJava8} is true; otherwise, returns "java7"
    */
-  private static String getGaeRuntimeJava(boolean isJava8) {
+  @VisibleForTesting
+  static String getGaeRuntimeJava(boolean isJava8) {
     return isJava8 ? "java8" : "java7";
   }
 

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
@@ -131,6 +131,9 @@ public class CloudSdkAppEngineDevServer1 implements AppEngineDevServer {
           + Joiner.on(",").withKeyValueSeparator("=").join(appEngineEnvironment));
     }
 
+    appEngineEnvironment.putAll(
+        getLocalAppEngineEnvironmentVariables(isJava8(config.getServices())));
+
     if (config.getEnvironment() != null) {
       appEngineEnvironment.putAll(config.getEnvironment());
     }
@@ -240,6 +243,24 @@ public class CloudSdkAppEngineDevServer1 implements AppEngineDevServer {
       }
     }
     return allAppEngineEnvironment;
+  }
+
+  /**
+   * Gets a {@code Map<String, String>} of the environment variables for running the {@link
+   * AppEngineDevServer}.
+   *
+   * @param isJava8 if {@code true}, uses java8 as the GAE_RUNTIME; otherwise, uses java7
+   * @return {@code Map<String, String>} that maps from the environment variable name to its value
+   */
+  private static Map<String, String> getLocalAppEngineEnvironmentVariables(boolean isJava8) {
+    Map<String, String> environment = Maps.newHashMap();
+
+    String gaeEnv = "localdev";
+    String gaeRuntime = isJava8 ? "java8" : "java7";
+    environment.put("GAE_ENV", gaeEnv);
+    environment.put("GAE_RUNTIME", gaeRuntime);
+
+    return environment;
   }
 
   private static void checkAndWarnDuplicateEnvironmentVariables(Map<String, String> newEnvironment,

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
@@ -131,7 +131,7 @@ public class CloudSdkAppEngineDevServer1 implements AppEngineDevServer {
           + Joiner.on(",").withKeyValueSeparator("=").join(appEngineEnvironment));
     }
 
-    String gaeRuntime = getGaeRuntime(isJava8(config.getServices()));
+    String gaeRuntime = getGaeRuntimeJava(isJava8(config.getServices()));
     appEngineEnvironment.putAll(getLocalAppEngineEnvironmentVariables(gaeRuntime));
 
     if (config.getEnvironment() != null) {
@@ -263,11 +263,11 @@ public class CloudSdkAppEngineDevServer1 implements AppEngineDevServer {
   }
 
   /**
-   *
+   * Gets the App Engine runtime ID for Java runtimes.
    * @param isJava8 if {@code true}, use Java 8; otherwise, use Java 7
    * @return "java8" if {@code isJava8} is true; otherwise, returns "java7"
    */
-  private static String getGaeRuntime(boolean isJava8) {
+  private static String getGaeRuntimeJava(boolean isJava8) {
     return isJava8 ? "java8" : "java7";
   }
 

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1Test.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1Test.java
@@ -459,4 +459,33 @@ public class CloudSdkAppEngineDevServer1Test {
     verify(sdk).runDevAppServer1Command(any(List.class), any(List.class), any(Map.class),
         eq((File) null) /* workingDirectory */);
   }
+
+  @Test
+  public void testGetLocalAppEngineEnvironmentVariables_java7() {
+    Map<String, String> environment = CloudSdkAppEngineDevServer1.getLocalAppEngineEnvironmentVariables("java7");
+    Assert.assertEquals(expectedJava7Environment, environment);
+  }
+
+  @Test
+  public void testGetLocalAppEngineEnvironmentVariables_java8() {
+    Map<String, String> environment = CloudSdkAppEngineDevServer1.getLocalAppEngineEnvironmentVariables("java8");
+    Assert.assertEquals(expectedJava8Environment, environment);
+  }
+
+  @Test
+  public void testGetLocalAppEngineEnvironmentVariables_other() {
+    Map<String, String> environment = CloudSdkAppEngineDevServer1.getLocalAppEngineEnvironmentVariables("some_other_runtime");
+    Map<String, String> expectedEnvironment = ImmutableMap.of("GAE_ENV", "localdev", "GAE_RUNTIME", "some_other_runtime");
+    Assert.assertEquals(expectedEnvironment, environment);
+  }
+
+  @Test
+  public void testGetGaeRuntimeJava_isJava8() {
+    Assert.assertEquals("java8", CloudSdkAppEngineDevServer1.getGaeRuntimeJava(true));
+  }
+
+  @Test
+  public void testGetGaeRuntimeJava_isNotJava8() {
+    Assert.assertEquals("java7", CloudSdkAppEngineDevServer1.getGaeRuntimeJava(false));
+  }
 }

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1Test.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1Test.java
@@ -171,7 +171,7 @@ public class CloudSdkAppEngineDevServer1Test {
         java8Service /* workingDirectory */);
 
     SpyVerifier.newVerifier(configuration).verifyDeclaredGetters(
-        ImmutableMap.of("getServices", 8, "getJavaHomeDir", 2, "getJvmFlags", 2));
+        ImmutableMap.of("getServices", 7, "getJavaHomeDir", 2, "getJvmFlags", 2));
 
     // verify we are checking and ignoring these parameters
     Map<String, Object> paramWarnings = new HashMap<>();


### PR DESCRIPTION
Fixes #444 . 

Does this for CloudSdkAppEngineDevServer1. Will write the tests if this is the way we want to do it.