### PR TITLE
Remove unnecessary Callable interface. Fortify checks and cleanup.

### DIFF
--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Downloader.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Downloader.java
@@ -22,16 +22,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.concurrent.Callable;
 
-/**
- * Downloader for downloading a single Cloud SDK archive. It is a callable we use in chained
- * asynchronous calls.
- */
-final class Downloader implements Callable<Path> {
+/** Downloader for downloading a single Cloud SDK archive. */
+final class Downloader {
 
   static final int BUFFER_SIZE = 8 * 1024;
   private final URL address;
@@ -48,24 +45,30 @@ final class Downloader implements Callable<Path> {
     this.messageListener = messageListener;
   }
 
-  /** Download and return a {@link Path} to downloaded archive. */
-  @Override
-  public Path call() throws IOException, InterruptedException {
+  /**
+   * Download and return a {@link Path} to downloaded archive, this will overwrite a previously
+   * existing file.
+   */
+  public Path download() throws IOException, InterruptedException {
     if (!Files.exists(destinationFile.getParent())) {
       Files.createDirectories(destinationFile.getParent());
+    }
+
+    if (Files.exists(destinationFile)) {
+      throw new FileAlreadyExistsException(destinationFile.toString());
     }
 
     URLConnection connection = address.openConnection();
     connection.setRequestProperty("User-Agent", userAgentString);
 
-    try (BufferedOutputStream out =
-        new BufferedOutputStream(
-            Files.newOutputStream(destinationFile, StandardOpenOption.CREATE_NEW))) {
-      try (InputStream in = connection.getInputStream()) {
-        messageListener.message("Downloading " + address);
+    try (InputStream in = connection.getInputStream()) {
+      long contentLength = connection.getContentLengthLong();
 
-        long contentLength = connection.getContentLengthLong();
+      messageListener.message("Downloading " + address);
 
+      try (BufferedOutputStream out =
+          new BufferedOutputStream(
+              Files.newOutputStream(destinationFile, StandardOpenOption.CREATE_NEW))) {
         int bytesRead;
         byte[] buffer = new byte[BUFFER_SIZE];
 
@@ -77,8 +80,9 @@ final class Downloader implements Callable<Path> {
         messageListener.message("0/" + String.valueOf(contentLength));
         while ((bytesRead = in.read(buffer)) != -1) {
           if (Thread.currentThread().isInterrupted()) {
-            messageListener.message("Downloader was interrupted");
-            throw new InterruptedException("Downloader was interrupted");
+            messageListener.message("Process was interrupted");
+            cleanUp();
+            throw new InterruptedException("Process was interrupted");
           }
           out.write(buffer, 0, bytesRead);
 
@@ -88,12 +92,17 @@ final class Downloader implements Callable<Path> {
           if (totalBytesRead == contentLength || bytesSinceLastUpdate > updateThreshold) {
             messageListener.message(
                 String.valueOf(totalBytesRead) + "/" + String.valueOf(contentLength));
+            lastUpdated = totalBytesRead;
           }
-          lastUpdated = totalBytesRead;
         }
       }
     }
     messageListener.message("Download complete");
     return destinationFile;
+  }
+
+  private void cleanUp() throws IOException {
+    messageListener.message("Cleaning up...");
+    Files.deleteIfExists(destinationFile);
   }
 }

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Downloader.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Downloader.java
@@ -80,9 +80,10 @@ final class Downloader {
         messageListener.message("0/" + String.valueOf(contentLength));
         while ((bytesRead = in.read(buffer)) != -1) {
           if (Thread.currentThread().isInterrupted()) {
-            messageListener.message("Process was interrupted");
+            messageListener.message("Download was interrupted");
+            messageListener.message("Cleaning up...");
             cleanUp();
-            throw new InterruptedException("Process was interrupted");
+            throw new InterruptedException("Download was interrupted");
           }
           out.write(buffer, 0, bytesRead);
 
@@ -102,7 +103,6 @@ final class Downloader {
   }
 
   private void cleanUp() throws IOException {
-    messageListener.message("Cleaning up...");
     Files.deleteIfExists(destinationFile);
   }
 }

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Extractor.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Extractor.java
@@ -18,17 +18,19 @@ package com.google.cloud.tools.managedcloudsdk.install;
 
 import com.google.cloud.tools.managedcloudsdk.MessageListener;
 import com.google.common.annotations.VisibleForTesting;
-import java.io.FileNotFoundException;
+import com.google.common.base.Preconditions;
 import java.io.IOException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.concurrent.Callable;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 
 /**
- * Extractor for extracting files from a single Cloud SDK archive. It is a callable we use in
- * chained asynchronous calls. Use {@link ExtractorProvider} to provide extractor implementation.
+ * Extractor for extracting files from a single archive. Use {@link ExtractorProvider} to provide
+ * extractor implementation.
  */
-final class Extractor<T extends ExtractorProvider> implements Callable<Path> {
+final class Extractor<T extends ExtractorProvider> {
   private final Path archive;
   private final Path destination;
   private final ExtractorProvider extractorProvider;
@@ -42,24 +44,60 @@ final class Extractor<T extends ExtractorProvider> implements Callable<Path> {
     this.messageListener = messageListener;
   }
 
-  /** Extract and return a {@link Path} to the Cloud SDK home directory. */
-  @Override
-  public Path call() throws IOException {
+  /** Extract and return a {@link Path} to the extraction root. */
+  public Path extract() throws IOException, InterruptedException {
     messageListener.message("Extracting archive: " + archive);
 
-    extractorProvider.extract(archive, destination, messageListener);
-
-    // this is convention
-    Path cloudSdkHome = destination.resolve("google-cloud-sdk");
-    if (!Files.isDirectory(cloudSdkHome)) {
-      throw new FileNotFoundException(
-          "After extraction, Cloud SDK home not found at " + cloudSdkHome);
+    try {
+      extractorProvider.extract(archive, destination, messageListener);
+    } catch (IOException ex) {
+      try {
+        messageListener.message("Extraction failed, cleaning up " + destination);
+        cleanUp(destination);
+      } catch (Exception exx) {
+        messageListener.message("Failed to cleanup directory");
+      }
+      // intentional rethrow after cleanup
+      throw ex;
     }
-    return cloudSdkHome;
+
+    // we do not allow interrupt mid extraction, so catch it here, we still end up
+    // with a valid directory though, so don't clean it up.
+    if (Thread.currentThread().isInterrupted()) {
+      messageListener.message("Process was interrupted");
+      throw new InterruptedException("Process was interrupted");
+    }
+
+    return destination;
   }
 
   @VisibleForTesting
   ExtractorProvider getExtractorProvider() {
     return extractorProvider;
+  }
+
+  private void cleanUp(final Path target) throws IOException {
+    Preconditions.checkArgument(Files.isDirectory(target));
+    Files.walkFileTree(
+        target,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+              throws IOException {
+            Files.delete(file);
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult postVisitDirectory(Path dir, IOException ex) throws IOException {
+            if (ex == null) {
+              Files.delete(dir);
+              return FileVisitResult.CONTINUE;
+            } else {
+              // directory iteration failed
+              throw ex;
+            }
+          }
+        });
   }
 }

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Extractor.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Extractor.java
@@ -76,6 +76,7 @@ final class Extractor<T extends ExtractorProvider> {
     return extractorProvider;
   }
 
+  // TODO: After move to Java8, use guava 21.0 recursive delete.
   private void cleanUp(final Path target) throws IOException {
     Preconditions.checkArgument(Files.isDirectory(target));
     Files.walkFileTree(

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Extractor.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Extractor.java
@@ -54,7 +54,7 @@ final class Extractor<T extends ExtractorProvider> {
       try {
         messageListener.message("Extraction failed, cleaning up " + destination);
         cleanUp(destination);
-      } catch (Exception exx) {
+      } catch (IOException exx) {
         messageListener.message("Failed to cleanup directory");
       }
       // intentional rethrow after cleanup

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/ExtractorFactory.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/ExtractorFactory.java
@@ -34,7 +34,8 @@ final class ExtractorFactory {
    *     ZipExtractorProvider} for ".zip"
    * @throws UnknownArchiveTypeException if not ".tar.gz" or ".zip"
    */
-  public Extractor newExtractor(Path archive, Path destination, MessageListener messageListener)
+  public Extractor<? extends ExtractorProvider> newExtractor(
+      Path archive, Path destination, MessageListener messageListener)
       throws UnknownArchiveTypeException {
 
     if (archive.toString().toLowerCase().endsWith(".tar.gz")) {

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Installer.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Installer.java
@@ -24,14 +24,10 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
-/**
- * Installer for running install scripts in a Cloud SDK download. It is a callable we use in chained
- * asynchronous calls.
- */
-final class Installer<T extends InstallScriptProvider> implements Callable<Path> {
+/** Installer for running install scripts in a Cloud SDK download. */
+final class Installer<T extends InstallScriptProvider> {
 
   private final Path installedSdkRoot;
   private final InstallScriptProvider installScriptProvider;
@@ -54,8 +50,7 @@ final class Installer<T extends InstallScriptProvider> implements Callable<Path>
   }
 
   /** Install and return a {@link Path} to the Cloud SDK home directory. */
-  @Override
-  public Path call() throws IOException, ExecutionException {
+  public Path install() throws IOException, ExecutionException {
 
     List<String> command = new ArrayList<>(installScriptProvider.getScriptCommandLine());
     // now configure parameters (not OS specific)

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/InstallerFactory.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/InstallerFactory.java
@@ -46,9 +46,10 @@ final class InstallerFactory {
    * @param messageListener listener on installer script output
    * @return a {@link Installer} instance.
    */
-  public Installer newInstaller(Path installedSdkRoot, MessageListener messageListener) {
+  public Installer<? extends InstallScriptProvider> newInstaller(
+      Path installedSdkRoot, MessageListener messageListener) {
 
-    return new Installer(
+    return new Installer<>(
         installedSdkRoot,
         getInstallScriptProvider(),
         usageReporting,

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/DownloaderTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/DownloaderTest.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.nio.charset.Charset;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -46,20 +47,31 @@ public class DownloaderTest {
     MockitoAnnotations.initMocks(this);
   }
 
+  private Path createTestRemoteResource(long sizeInBytes) throws IOException {
+
+    Path testFile = tmp.newFile().toPath();
+    try (BufferedWriter writer = Files.newBufferedWriter(testFile, Charset.defaultCharset())) {
+      for (long i = 0; i < sizeInBytes; i++) {
+        writer.write('a');
+      }
+    }
+    return testFile;
+  }
+
   @Test
-  public void testDownloadURL_createsNewDirectory() throws IOException, InterruptedException {
+  public void testDownload_createsNewDirectory() throws IOException, InterruptedException {
     Path destination = tmp.getRoot().toPath().resolve("dir-to-create").resolve("destination-file");
     Path testSourceFile = createTestRemoteResource(1);
     URL fakeRemoteResource = testSourceFile.toUri().toURL();
 
     Downloader downloader = new Downloader(fakeRemoteResource, destination, null, messageListener);
 
-    Path downloaderDestination = downloader.call();
+    Path downloaderDestination = downloader.download();
     Assert.assertEquals(destination, downloaderDestination);
   }
 
   @Test
-  public void testDownloadURL_worksWithNullProgressListener()
+  public void testDownload_worksWithNullProgressListener()
       throws IOException, InterruptedException {
 
     Path destination = tmp.getRoot().toPath().resolve("destination-file");
@@ -68,12 +80,12 @@ public class DownloaderTest {
 
     Downloader downloader = new Downloader(fakeRemoteResource, destination, null, messageListener);
 
-    Path downloaderDestination = downloader.call();
+    Path downloaderDestination = downloader.download();
     Assert.assertEquals(destination, downloaderDestination);
   }
 
   @Test
-  public void testDownloadURL() throws IOException, InterruptedException {
+  public void testDownload() throws IOException, InterruptedException {
     Path destination = tmp.getRoot().toPath().resolve("destination-file");
     long testFileSize = Downloader.BUFFER_SIZE * 10 + 1;
     Path testSourceFile = createTestRemoteResource(testFileSize);
@@ -81,7 +93,7 @@ public class DownloaderTest {
 
     Downloader downloader = new Downloader(fakeRemoteResource, destination, null, messageListener);
 
-    Path downloaderDestination = downloader.call();
+    Path downloaderDestination = downloader.download();
     Assert.assertEquals(destination, downloaderDestination);
 
     Assert.assertArrayEquals(Files.readAllBytes(destination), Files.readAllBytes(testSourceFile));
@@ -109,19 +121,8 @@ public class DownloaderTest {
     Assert.assertEquals(testFileSize, lastRead);
   }
 
-  private Path createTestRemoteResource(long sizeInBytes) throws IOException {
-
-    Path testFile = tmp.newFile().toPath();
-    try (BufferedWriter writer = Files.newBufferedWriter(testFile, Charset.defaultCharset())) {
-      for (long i = 0; i < sizeInBytes; i++) {
-        writer.write('a');
-      }
-    }
-    return testFile;
-  }
-
   @Test
-  public void testDownloadURL_userAgentSet() throws IOException, InterruptedException {
+  public void testDownload_userAgentSet() throws IOException, InterruptedException {
     Path destination = tmp.getRoot().toPath().resolve("destination-file");
 
     final URLConnection mockConnection = Mockito.mock(URLConnection.class);
@@ -139,10 +140,25 @@ public class DownloaderTest {
         new Downloader(testUrl, destination, "test-user-agent", messageListener);
 
     try {
-      downloader.call();
+      downloader.download();
     } catch (Exception ex) {
       // ignore, we're only looking for user agent being set
     }
     Mockito.verify(mockConnection).setRequestProperty("User-Agent", "test-user-agent");
+  }
+
+  @Test
+  public void testDownload_failIfExists() throws IOException, InterruptedException {
+    Path destination = tmp.getRoot().toPath().resolve("destination-file");
+    Files.createFile(destination);
+
+    Downloader downloader = new Downloader(null, destination, null, messageListener);
+
+    try {
+      downloader.download();
+      Assert.fail("FileAlreadyExistsException expected but not thrown.");
+    } catch (FileAlreadyExistsException ex) {
+      Assert.assertEquals(ex.getMessage(), destination.toString());
+    }
   }
 }

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/ExtractorFactoryTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/ExtractorFactoryTest.java
@@ -31,18 +31,14 @@ public class ExtractorFactoryTest {
   public void testNewExtractor_isZip() throws IOException, UnknownArchiveTypeException {
     Path archive = tmp.newFile("test-zip.zip").toPath();
     Extractor testExtractor = new ExtractorFactory().newExtractor(archive, null, null);
-    Assert.assertTrue(testExtractor instanceof Extractor);
-    Assert.assertTrue(
-        ((Extractor) testExtractor).getExtractorProvider() instanceof ZipExtractorProvider);
+    Assert.assertTrue(testExtractor.getExtractorProvider() instanceof ZipExtractorProvider);
   }
 
   @Test
   public void testNewExtractor_isTarGz() throws IOException, UnknownArchiveTypeException {
     Path archive = tmp.newFile("test-tar-gz.tar.gz").toPath();
     Extractor testExtractor = new ExtractorFactory().newExtractor(archive, null, null);
-    Assert.assertTrue(testExtractor instanceof Extractor);
-    Assert.assertTrue(
-        ((Extractor) testExtractor).getExtractorProvider() instanceof TarGzExtractorProvider);
+    Assert.assertTrue(testExtractor.getExtractorProvider() instanceof TarGzExtractorProvider);
   }
 
   @Test

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/InstallerTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/InstallerTest.java
@@ -65,7 +65,7 @@ public class InstallerTest {
             false,
             mockMessageListener,
             mockCommandExecutorFactory);
-    Path returnedSdkRoot = installer.call();
+    Path returnedSdkRoot = installer.install();
 
     Mockito.verify(mockCommandExecutor).run(getExpectedCommand(false));
     Assert.assertEquals(tmp.getRoot().toPath(), returnedSdkRoot);
@@ -80,7 +80,7 @@ public class InstallerTest {
             true,
             mockMessageListener,
             mockCommandExecutorFactory);
-    Path returnedSdkRoot = installer.call();
+    Path returnedSdkRoot = installer.install();
 
     Mockito.verify(mockCommandExecutor).run(getExpectedCommand(true));
     Assert.assertEquals(tmp.getRoot().toPath(), returnedSdkRoot);
@@ -98,7 +98,7 @@ public class InstallerTest {
             mockMessageListener,
             mockCommandExecutorFactory);
     try {
-      installer.call();
+      installer.install();
       Assert.fail("ExecutionException expected but not found.");
     } catch (ExecutionException ex) {
       Assert.assertEquals("Installer exited with non-zero exit code: 10", ex.getMessage());


### PR DESCRIPTION
It turns out chaining callables wasn't the best idea, easier to just async once. This CL also adds some more checks and cleanup for different parts.