### PR TITLE
Adds --server parameter for deploying configuration YAML.

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/api/deploy/DefaultDeployProjectConfigurationConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/deploy/DefaultDeployProjectConfigurationConfiguration.java
@@ -24,6 +24,7 @@ public class DefaultDeployProjectConfigurationConfiguration extends DefaultConfi
     implements DeployProjectConfigurationConfiguration {
 
   private File appEngineDirectory;
+  private String server;
 
   @Override
   public File getAppEngineDirectory() {
@@ -32,5 +33,14 @@ public class DefaultDeployProjectConfigurationConfiguration extends DefaultConfi
 
   public void setAppEngineDirectory(File appEngineDirectory) {
     this.appEngineDirectory = appEngineDirectory;
+  }
+
+  @Override
+  public String getServer() {
+    return server;
+  }
+
+  public void setServer(String server) {
+    this.server = server;
   }
 }

--- a/src/main/java/com/google/cloud/tools/appengine/api/deploy/DeployProjectConfigurationConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/deploy/DeployProjectConfigurationConfiguration.java
@@ -21,5 +21,8 @@ import java.io.File;
 
 /** Configuration for {@link AppEngineDeployment} project-level yaml deployments. */
 public interface DeployProjectConfigurationConfiguration extends Configuration {
+
   File getAppEngineDirectory();
+
+  String getServer();
 }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDeployment.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDeployment.java
@@ -139,6 +139,7 @@ public class CloudSdkAppEngineDeployment implements AppEngineDeployment {
     List<String> arguments = new ArrayList<>();
     arguments.add("deploy");
     arguments.add(deployable.toAbsolutePath().toString());
+    arguments.addAll(GcloudArgs.get("server", configuration.getServer()));
     arguments.addAll(GcloudArgs.get(configuration));
 
     try {

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDeploymentTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDeploymentTest.java
@@ -232,12 +232,19 @@ public class CloudSdkAppEngineDeploymentTest {
         new DefaultDeployProjectConfigurationConfiguration();
     File testConfigYaml = tmpDir.newFile("testconfig.yaml");
     configuration.setAppEngineDirectory(tmpDir.getRoot());
+    configuration.setServer("appengine.google.com");
     configuration.setProject("project");
 
     deployment.deployConfig("testconfig.yaml", configuration);
 
     List<String> expectedCommand =
-        ImmutableList.of("deploy", testConfigYaml.toString(), "--project", "project");
+        ImmutableList.of(
+            "deploy",
+            testConfigYaml.toString(),
+            "--server",
+            "appengine.google.com",
+            "--project",
+            "project");
 
     verify(sdk, times(1)).runAppCommand(eq(expectedCommand));
   }


### PR DESCRIPTION
This is for https://github.com/GoogleCloudPlatform/app-maven-plugin/issues/231.

This adds the `DefaultDeployConfiguration#server` parameter to `DefaultDeployProjectConfigurationConfiguration`.

Will need to release a new version after this is pushed to be used in app-maven-plugin.