### PR TITLE
Fix cloud SDK test, bug in Cloud SDK doesn't allow downgrades to 169

### DIFF
--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
@@ -36,7 +36,7 @@ public class ManagedCloudSdkTest {
 
   @Rule public TemporaryFolder tempDir = new TemporaryFolder();
 
-  private static final String FIXED_VERSION = "169.0.0";
+  private static final String FIXED_VERSION = "174.0.0";
   private final MessageCollector testListener = new MessageCollector();
   private final SdkComponent testComponent = SdkComponent.APP_ENGINE_JAVA;
 


### PR DESCRIPTION
Hopefully this fixes the downgrade issue in the integration test.