### PR TITLE
Swallow UnknownArchiveTypeException in SdkInstaller.install()

### DIFF
--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstaller.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstaller.java
@@ -47,8 +47,8 @@ public class SdkInstaller {
 
   /** Download and install a new Cloud SDK. */
   public Path install(final MessageListener messageListener)
-      throws IOException, InterruptedException, SdkInstallerException, UnknownArchiveTypeException,
-          CommandExecutionException, CommandExitException {
+      throws IOException, InterruptedException, SdkInstallerException, CommandExecutionException,
+          CommandExitException {
 
     FileResourceProvider fileResourceProvider =
         fileResourceProviderFactory.newFileResourceProvider();
@@ -83,17 +83,23 @@ public class SdkInstaller {
               + fileResourceProvider.getArchiveDestination());
     }
 
-    // extract and verify
-    extractorFactory
-        .newExtractor(
-            fileResourceProvider.getArchiveDestination(),
-            fileResourceProvider.getArchiveExtractionDestination(),
-            messageListener)
-        .extract();
-    if (!Files.isDirectory(fileResourceProvider.getExtractedSdkHome())) {
-      throw new SdkInstallerException(
-          "Extraction succeeded but valid sdk home not found at "
-              + fileResourceProvider.getExtractedSdkHome());
+    try {
+      // extract and verify
+      extractorFactory
+          .newExtractor(
+              fileResourceProvider.getArchiveDestination(),
+              fileResourceProvider.getArchiveExtractionDestination(),
+              messageListener)
+          .extract();
+      if (!Files.isDirectory(fileResourceProvider.getExtractedSdkHome())) {
+        throw new SdkInstallerException(
+            "Extraction succeeded but valid sdk home not found at "
+                + fileResourceProvider.getExtractedSdkHome());
+      }
+    } catch (UnknownArchiveTypeException e) {
+      // fileResourceProviderFactory.newFileResourceProvider() creates a fileResourceProvider that
+      // either returns .tar.gz or .zip for getArchiveDestination().
+      throw new RuntimeException();
     }
 
     // install if necessary

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstaller.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstaller.java
@@ -98,7 +98,7 @@ public class SdkInstaller {
       }
     } catch (UnknownArchiveTypeException e) {
       // fileResourceProviderFactory.newFileResourceProvider() creates a fileResourceProvider that
-      // either returns .tar.gz or .zip for getArchiveDestination().
+      // returns either .tar.gz or .zip for getArchiveDestination().
       throw new RuntimeException();
     }
 

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstaller.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstaller.java
@@ -99,7 +99,7 @@ public class SdkInstaller {
     } catch (UnknownArchiveTypeException e) {
       // fileResourceProviderFactory.newFileResourceProvider() creates a fileResourceProvider that
       // returns either .tar.gz or .zip for getArchiveDestination().
-      throw new RuntimeException();
+      throw new RuntimeException(e);
     }
 
     // install if necessary


### PR DESCRIPTION
We construct `fileResourceProvider.getArchiveDestination()` so that it always returns either .tar.gz or .zip. See `FileResourceProviderFactory.newFileResourceProvider()` and `FileResourceProviderFactory.getVersionedFilename()`.

```java
      return new FileResourceProvider(
          new URL(LATEST_URL),
          downloads.resolve("google-cloud-sdk.tar.gz"),
```

```java
  private String getVersionedOsExtension() {
    switch (os.name()) {
      case WINDOWS:
        return "windows-" + getArchitectureString() + ".zip";
      case MAC:
        return "darwin-" + getArchitectureString() + ".tar.gz";
      case LINUX:
        return "linux-" + getArchitectureString() + ".tar.gz";
      default:
        // we can't actually get here
        throw new RuntimeException();
    }
  }
```

What do you think?