### PR TITLE
Avoid network access when listing installed components

### DIFF
--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
@@ -91,9 +91,8 @@ public class ManagedCloudSdk {
   }
 
   /**
-   * Query gcloud to see if component is installed. Gcloud makes a call to the server to check this,
-   * in future version we can explore the use of '--local-state-only' but that's a relatively new
-   * flag and may not work for all cases.
+   * Query gcloud to see if component is installed. Uses gcloud's '--local-state-only' to avoid
+   * network accesses.
    */
   public boolean hasComponent(SdkComponent component) throws ManagedSdkVerificationException {
     if (!Files.isRegularFile(getGcloud())) {
@@ -105,6 +104,7 @@ public class ManagedCloudSdk {
             getGcloud().toString(),
             "components",
             "list",
+            "--only-local-state",
             "--format=json",
             "--filter=id:" + component);
 

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
@@ -111,10 +111,11 @@ public class ManagedCloudSdk {
     try {
       String result = CommandCaller.newCaller().call(listComponentCommand, null, null);
       List<CloudSdkComponent> components = CloudSdkComponent.fromJsonList(result);
-      if (components.size() != 1) {
-        throw new ManagedSdkVerificationException("Invalid component" + component);
+      if (components.size() > 1) {
+        // not a unique component id
+        throw new ManagedSdkVerificationException("Invalid component " + component);
       }
-      return !components.get(0).getState().getName().equals("Not Installed");
+      return !components.isEmpty();
     } catch (CommandExecutionException | InterruptedException | CommandExitException ex) {
       throw new ManagedSdkVerificationException(ex);
     }

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
@@ -36,7 +36,7 @@ public class ManagedCloudSdkTest {
 
   @Rule public TemporaryFolder tempDir = new TemporaryFolder();
 
-  private static final String FIXED_VERSION = "174.0.0";
+  private static final String FIXED_VERSION = "178.0.0";
   private final MessageCollector testListener = new MessageCollector();
   private final SdkComponent testComponent = SdkComponent.APP_ENGINE_JAVA;
 


### PR DESCRIPTION
`ManagedCloudSdk#hasComponent()` uses `gcloud components list` to obtain the list of currently installed components, which causes a network access to fetch the latest component versions.  As noted in the code, Cloud SDK added a [`--only-local-state` flag in 170.0.0](https://cloud.google.com/sdk/docs/release-notes#google_cloud_sdk_4) to only list the locally-installed components and avoiding the network access.  Since our [minimum version is now 171.0.0](https://github.com/GoogleCloudPlatform/appengine-plugins-core/blob/master/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java#L60), and our [`ManagedCloudSdkTests` tests against 174.0.0](https://github.com/GoogleCloudPlatform/appengine-plugins-core/blob/master/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java#L39), we should use this flag.

Except it turns out 174.0.0 has a bug where no components results in two empty arrays reported:
```
$ ./google-cloud-sdk/bin/gcloud components list --only-local-state --format=json --filter=id:app-engine-java

Your current Cloud SDK version is: 174.0.0
[]
[]
```
This bug was fixed in 178.0.0, released [November 1, 2017](https://cloud.google.com/sdk/docs/release-notes#17800_2017-11-01).  So I bumped the `TEST_VERSION` to 178.0.0.