### PR TITLE
Clean up unthrown exceptions and nullness warnings

### DIFF
--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
@@ -152,7 +152,7 @@ public class ManagedCloudSdk {
   }
 
   // TODO : fix passthrough for useragent and client side usage reporting
-  public SdkInstaller newInstaller() throws UnsupportedOsException {
+  public SdkInstaller newInstaller() {
     String userAgentString = "google-cloud-tools-java";
     return SdkInstaller.newInstaller(managedSdkDirectory, version, osInfo, userAgentString, false);
   }

--- a/src/test/java/com/google/cloud/tools/libraries/json/CloudLibraryTest.java
+++ b/src/test/java/com/google/cloud/tools/libraries/json/CloudLibraryTest.java
@@ -17,12 +17,15 @@
 package com.google.cloud.tools.libraries.json;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.Iterables;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import java.util.List;
 import org.junit.Test;
 
 /** Unit tests for {@link CloudLibrary}. */
@@ -53,6 +56,7 @@ public final class CloudLibraryTest {
     CloudLibrary library = parse(createFullyPopulatedJson());
     CloudLibraryClient client = Iterables.getOnlyElement(library.getClients());
     CloudLibraryClientMavenCoordinates mavenCoordinates = client.getMavenCoordinates();
+    assertNotNull(mavenCoordinates);
     String serviceRole = Iterables.getOnlyElement(library.getServiceRoles());
 
     assertEquals(NAME, library.getName());
@@ -97,8 +101,10 @@ public final class CloudLibraryTest {
     String json = String.format("{transports:[%s, %s]}", transport1, transport2);
     CloudLibrary library = parse(json);
 
-    assertEquals(transport1, library.getTransports().get(0));
-    assertEquals(transport2, library.getTransports().get(1));
+    List<String> transports = library.getTransports();
+    assertTrue("expected 2 transports", transports != null && transports.size() == 2);
+    assertEquals(transport1, transports.get(0));
+    assertEquals(transport2, transports.get(1));
   }
 
   @Test
@@ -110,8 +116,10 @@ public final class CloudLibraryTest {
     String json = String.format("{clients:[%s, %s]}", client1Json, client2Json);
     CloudLibrary library = parse(json);
 
-    assertEquals(client1, library.getClients().get(0).getName());
-    assertEquals(client2, library.getClients().get(1).getName());
+    List<CloudLibraryClient> clients = library.getClients();
+    assertTrue("expected 2 clients", clients != null && clients.size() == 2);
+    assertEquals(client1, clients.get(0).getName());
+    assertEquals(client2, clients.get(1).getName());
   }
 
   @Test

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
@@ -21,7 +21,6 @@ import com.google.cloud.tools.managedcloudsdk.command.CommandExitException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandRunner;
 import com.google.cloud.tools.managedcloudsdk.components.SdkComponent;
 import com.google.cloud.tools.managedcloudsdk.install.SdkInstallerException;
-import com.google.cloud.tools.managedcloudsdk.install.UnknownArchiveTypeException;
 import java.io.IOException;
 import java.util.Arrays;
 import org.junit.Assert;
@@ -53,7 +52,7 @@ public class ManagedCloudSdkTest {
   public void testManagedCloudSdk_fixedVersion()
       throws BadCloudSdkVersionException, UnsupportedOsException, IOException, CommandExitException,
           InterruptedException, ManagedSdkVerificationException, ManagedSdkVersionMismatchException,
-          UnknownArchiveTypeException, CommandExecutionException, SdkInstallerException {
+          CommandExecutionException, SdkInstallerException {
     ManagedCloudSdk testSdk =
         new ManagedCloudSdk(
             new Version(FIXED_VERSION), tempDir.getRoot().toPath(), OsInfo.getSystemOsInfo());
@@ -87,7 +86,7 @@ public class ManagedCloudSdkTest {
   public void testManagedCloudSdk_latest()
       throws UnsupportedOsException, ManagedSdkVerificationException,
           ManagedSdkVersionMismatchException, InterruptedException, CommandExecutionException,
-          CommandExitException, UnknownArchiveTypeException, IOException, SdkInstallerException {
+          CommandExitException, IOException, SdkInstallerException {
     ManagedCloudSdk testSdk =
         new ManagedCloudSdk(Version.LATEST, tempDir.getRoot().toPath(), OsInfo.getSystemOsInfo());
 

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/OsInfoTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/OsInfoTest.java
@@ -60,7 +60,7 @@ public class OsInfoTest {
   }
 
   @Test
-  public void testGetSystemArchitecture_is64() throws UnsupportedOsException {
+  public void testGetSystemArchitecture_is64() {
     Assert.assertEquals(OsInfo.Architecture.X86_64, OsInfo.getSystemArchitecture("64"));
     Assert.assertEquals(OsInfo.Architecture.X86_64, OsInfo.getSystemArchitecture("universal"));
     Assert.assertEquals(OsInfo.Architecture.X86_64, OsInfo.getSystemArchitecture("junk64Junk"));
@@ -69,7 +69,7 @@ public class OsInfoTest {
   }
 
   @Test
-  public void testGetSystemArchitecture_defaultIs32() throws UnsupportedOsException {
+  public void testGetSystemArchitecture_defaultIs32() {
     Assert.assertEquals(OsInfo.Architecture.X86, OsInfo.getSystemArchitecture("32"));
     Assert.assertEquals(OsInfo.Architecture.X86, OsInfo.getSystemArchitecture("junk32junk"));
     Assert.assertEquals(OsInfo.Architecture.X86, OsInfo.getSystemArchitecture("junk"));

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/VersionTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/VersionTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 public class VersionTest {
 
   @Test
-  public void testNewVersion_defaultLatest() throws BadCloudSdkVersionException {
+  public void testNewVersion_defaultLatest() {
     Assert.assertEquals("LATEST", Version.LATEST.getVersion());
   }
 

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/command/CommandRunnerTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/command/CommandRunnerTest.java
@@ -26,7 +26,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -54,7 +53,7 @@ public class CommandRunnerTest {
   private CommandRunner testCommandRunner;
 
   @Before
-  public void setUp() throws IOException, ExecutionException, InterruptedException {
+  public void setUp() throws IOException, InterruptedException {
     MockitoAnnotations.initMocks(this);
 
     fakeCommand = Arrays.asList("gcloud", "test", "--option");

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstallerTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstallerTest.java
@@ -20,7 +20,6 @@ import com.google.cloud.tools.managedcloudsdk.MessageListener;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExecutionException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExitException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandRunner;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -44,7 +43,7 @@ public class SdkComponentInstallerTest {
   private SdkComponent testComponent = SdkComponent.APP_ENGINE_JAVA;
 
   @Before
-  public void setUpMocks() throws IOException {
+  public void setUpMocks() {
     MockitoAnnotations.initMocks(this);
     fakeGcloud = testDir.getRoot().toPath().resolve("fake-gcloud");
   }

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/DownloaderTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/DownloaderTest.java
@@ -114,7 +114,7 @@ public class DownloaderTest {
   }
 
   @Test
-  public void testDownload_userAgentSet() throws IOException, InterruptedException {
+  public void testDownload_userAgentSet() throws IOException {
     Path destination = tmp.getRoot().toPath().resolve("destination-file");
 
     final URLConnection mockConnection = Mockito.mock(URLConnection.class);

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/InstallerTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/InstallerTest.java
@@ -20,12 +20,10 @@ import com.google.cloud.tools.managedcloudsdk.MessageListener;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExecutionException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExitException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandRunner;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,7 +45,7 @@ public class InstallerTest {
   private List<String> fakeCommand = Arrays.asList("scriptexec", "test-install.script");
 
   @Before
-  public void setUp() throws IOException, ExecutionException, InterruptedException {
+  public void setUp() {
     MockitoAnnotations.initMocks(this);
 
     fakeWorkingDirectory = tmp.getRoot().toPath();

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstallerTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstallerTest.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.concurrent.ExecutionException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -69,8 +68,8 @@ public class SdkInstallerTest {
 
   @Before
   public void setUpMocksAndFakes()
-      throws IOException, InterruptedException, UnknownArchiveTypeException, ExecutionException,
-          CommandExitException, CommandExecutionException {
+      throws IOException, InterruptedException, UnknownArchiveTypeException, CommandExitException,
+          CommandExecutionException {
     MockitoAnnotations.initMocks(this);
 
     Path managedSdkRoot = testDir.newFolder("managed-sdk-test-home").toPath();
@@ -165,7 +164,7 @@ public class SdkInstallerTest {
   @Test
   public void testDownloadSdk_successRun()
       throws CommandExecutionException, InterruptedException, IOException, CommandExitException,
-          SdkInstallerException, UnknownArchiveTypeException {
+          SdkInstallerException {
 
     SdkInstaller testInstaller =
         new SdkInstaller(
@@ -181,7 +180,7 @@ public class SdkInstallerTest {
   @Test
   public void testDownloadSdk_successRunWithoutExplicitInstall()
       throws CommandExecutionException, InterruptedException, IOException, CommandExitException,
-          SdkInstallerException, UnknownArchiveTypeException {
+          SdkInstallerException {
     SdkInstaller testInstaller =
         new SdkInstaller(
             fileResourceProviderFactory,
@@ -195,8 +194,7 @@ public class SdkInstallerTest {
 
   @Test
   public void testDownloadSdk_failedDownload()
-      throws InterruptedException, CommandExecutionException, CommandExitException,
-          UnknownArchiveTypeException, IOException {
+      throws InterruptedException, CommandExecutionException, CommandExitException, IOException {
 
     SdkInstaller testInstaller =
         new SdkInstaller(
@@ -216,8 +214,7 @@ public class SdkInstallerTest {
 
   @Test
   public void testDownloadSdk_failedExtraction()
-      throws InterruptedException, ExecutionException, UnknownArchiveTypeException, IOException,
-          CommandExitException, CommandExecutionException {
+      throws InterruptedException, IOException, CommandExitException, CommandExecutionException {
 
     SdkInstaller testInstaller =
         new SdkInstaller(
@@ -237,8 +234,7 @@ public class SdkInstallerTest {
 
   @Test
   public void testDownloadSdk_failedInstallation()
-      throws InterruptedException, ExecutionException, UnknownArchiveTypeException, IOException,
-          CommandExitException, CommandExecutionException {
+      throws InterruptedException, IOException, CommandExitException, CommandExecutionException {
 
     SdkInstaller testInstaller =
         new SdkInstaller(

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/process/ProcessExecutorTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/process/ProcessExecutorTest.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,7 +54,7 @@ public class ProcessExecutorTest {
   }
 
   @Test
-  public void testRun() throws IOException, InterruptedException, ExecutionException {
+  public void testRun() throws IOException, InterruptedException {
     // Mocks the environment for the mockProcessBuilder to put the environment map in.
     Map<String, String> environmentInput = new HashMap<>();
     environmentInput.put("ENV1", "val1");
@@ -80,8 +79,7 @@ public class ProcessExecutorTest {
   }
 
   @Test
-  public void testRun_nonZeroExitCodePassthrough()
-      throws IOException, InterruptedException, ExecutionException {
+  public void testRun_nonZeroExitCodePassthrough() throws IOException, InterruptedException {
 
     Mockito.when(mockProcess.waitFor()).thenReturn(123);
 

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/update/SdkUpdaterTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/update/SdkUpdaterTest.java
@@ -20,7 +20,6 @@ import com.google.cloud.tools.managedcloudsdk.MessageListener;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExecutionException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExitException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandRunner;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -43,7 +42,7 @@ public class SdkUpdaterTest {
   private Path fakeGcloud;
 
   @Before
-  public void setUpFakesAndMocks() throws IOException {
+  public void setUpFakesAndMocks() {
     MockitoAnnotations.initMocks(this);
     fakeGcloud = testDir.getRoot().toPath().resolve("fake-gcloud");
   }


### PR DESCRIPTION
Minor cleanups of upthrown exceptions and nullness warnings.  The `UnsupportedOsException`s are actually thrown in the `newManagedSdk()` variants, which must be called to obtain an `SdkInstaller`.