### PR TITLE
Update build target to java8, maven version to 3.5.2

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://storage.googleapis.com/cloud-tools-for-java-team-kokoro-build-cache/apache-maven-3.5.0-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.2/apache-maven-3.5.2-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -147,8 +147,8 @@
           <forceJavacCompilerUse>true</forceJavacCompilerUse>
           <!-- maven-compiler-plugin defaults to targeting Java 5, but our javac
           only supports >=6 -->
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
         <dependencies>
           <dependency>
@@ -258,7 +258,7 @@
           -->
           <instructions>
             <Bundle-SymbolicName>com.google.cloud.tools.appengine</Bundle-SymbolicName>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.7</Bundle-RequiredExecutionEnvironment>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Import-Package>!javax.annotation,*</Import-Package>
             <Eclipse-BuddyPolicy>registered</Eclipse-BuddyPolicy>
           </instructions>


### PR DESCRIPTION
fixes #539

This PR will mandate all further tooling builds target java8 or higher.
