### PR TITLE
Fix checkstyle config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,6 @@
         </configuration>
         <executions>
           <execution>
-            <id>default-cli</id>
             <phase>validate</phase>
             <goals>
               <goal>check</goal>
@@ -225,24 +224,22 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.2</version>
+            <version>8.8</version>
           </dependency>
         </dependencies>
         <configuration>
           <consoleOutput>false</consoleOutput>
           <failOnViolation>true</failOnViolation>
           <violationSeverity>warning</violationSeverity>
+          <configLocation>google_checks.xml</configLocation>
+          <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
         </configuration>
         <executions>
           <execution>
-            <id>google-checks</id>
+            <phase>verify</phase>
             <goals>
               <goal>check</goal>
             </goals>
-            <configuration>
-              <configLocation>google_checks.xml</configLocation>
-              <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
-            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
you can now run "checkstyle:check" and it will use the google style config.

the `<id>` tag doesn't do anything, so I removed them.