### PR TITLE
Reduce managed SDK install path length

### DIFF
--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
@@ -205,20 +205,20 @@ public class ManagedCloudSdk {
     switch (osName) {
       case WINDOWS:
         // Shorter path to mitigate the length limit issue on Windows
-        cloudSdkPartialPath = Paths.get("google", "ct4j-cloud-sdk");
-        xdgPath = userHome.resolve(".cache").resolve(cloudSdkPartialPath);
+        Path shortCloudSdkPartialPath = Paths.get("google", "ct4j-cloud-sdk");
+        Path windowsXdgPath = userHome.resolve(".cache").resolve(shortCloudSdkPartialPath);
 
         String localAppDataEnv = environment.get("LOCALAPPDATA");
         if (localAppDataEnv == null || localAppDataEnv.trim().isEmpty()) {
           logger.warning("LOCALAPPDATA environment is invalid or missing");
-          return xdgPath;
+          return windowsXdgPath;
         }
         Path localAppData = Paths.get(localAppDataEnv);
         if (!Files.exists(localAppData)) {
           logger.warning(localAppData.toString() + " does not exist");
-          return xdgPath;
+          return windowsXdgPath;
         }
-        return localAppData.resolve(cloudSdkPartialPath);
+        return localAppData.resolve(shortCloudSdkPartialPath);
 
       case MAC:
         Path applicationSupport = userHome.resolve("Library").resolve("Application Support");

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
@@ -199,11 +199,15 @@ public class ManagedCloudSdk {
   static Path getOsSpecificManagedSdkHome(
       OsInfo.Name osName, Properties systemProperties, Map<String, String> environment) {
     Path userHome = Paths.get(systemProperties.getProperty("user.home"));
-    Path cloudSdkPartialPath = Paths.get("google", "ct4j-cloud-sdk");
+    Path cloudSdkPartialPath = Paths.get("google-cloud-tools-java", "managed-cloud-sdk");
     Path xdgPath = userHome.resolve(".cache").resolve(cloudSdkPartialPath);
 
     switch (osName) {
       case WINDOWS:
+        // Shorter path to mitigate the length limit issue on Windows
+        cloudSdkPartialPath = Paths.get("google", "ct4j-cloud-sdk");
+        xdgPath = userHome.resolve(".cache").resolve(cloudSdkPartialPath);
+
         String localAppDataEnv = environment.get("LOCALAPPDATA");
         if (localAppDataEnv == null || localAppDataEnv.trim().isEmpty()) {
           logger.warning("LOCALAPPDATA environment is invalid or missing");

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
@@ -199,7 +199,7 @@ public class ManagedCloudSdk {
   static Path getOsSpecificManagedSdkHome(
       OsInfo.Name osName, Properties systemProperties, Map<String, String> environment) {
     Path userHome = Paths.get(systemProperties.getProperty("user.home"));
-    Path cloudSdkPartialPath = Paths.get("google-cloud-tools-java", "managed-cloud-sdk");
+    Path cloudSdkPartialPath = Paths.get("google", "ct4j-cloud-sdk");
     Path xdgPath = userHome.resolve(".cache").resolve(cloudSdkPartialPath);
 
     switch (osName) {

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -44,6 +45,7 @@ public class ManagedCloudSdkTest {
   @Rule public TemporaryFolder tempDir = new TemporaryFolder();
 
   private static final String FIXED_VERSION = "178.0.0";
+  private static final Map<String, String> EMPTY_MAP = Collections.emptyMap();
   private final MessageCollector testListener = new MessageCollector();
   private final ProgressListener testProgressListener = new NullProgressListener();
   private final SdkComponent testComponent = SdkComponent.APP_ENGINE_JAVA;
@@ -57,14 +59,22 @@ public class ManagedCloudSdkTest {
         }
       };
 
+  private Path userHome;
+  private final Properties fakeProperties = new Properties();
+
+  @Before
+  public void setUp() {
+    userHome = tempDir.getRoot().toPath();
+    fakeProperties.put("user.home", userHome.toString());
+  }
+
   @Test
   public void testManagedCloudSdk_fixedVersion()
       throws BadCloudSdkVersionException, UnsupportedOsException, IOException, CommandExitException,
           InterruptedException, ManagedSdkVerificationException, ManagedSdkVersionMismatchException,
           CommandExecutionException, SdkInstallerException {
     ManagedCloudSdk testSdk =
-        new ManagedCloudSdk(
-            new Version(FIXED_VERSION), tempDir.getRoot().toPath(), OsInfo.getSystemOsInfo());
+        new ManagedCloudSdk(new Version(FIXED_VERSION), userHome, OsInfo.getSystemOsInfo());
 
     Assert.assertFalse(testSdk.isInstalled());
     Assert.assertFalse(testSdk.hasComponent(testComponent));
@@ -99,7 +109,7 @@ public class ManagedCloudSdkTest {
           ManagedSdkVersionMismatchException, InterruptedException, CommandExecutionException,
           CommandExitException, IOException, SdkInstallerException {
     ManagedCloudSdk testSdk =
-        new ManagedCloudSdk(Version.LATEST, tempDir.getRoot().toPath(), OsInfo.getSystemOsInfo());
+        new ManagedCloudSdk(Version.LATEST, userHome, OsInfo.getSystemOsInfo());
 
     Assert.assertFalse(testSdk.isInstalled());
     Assert.assertFalse(testSdk.isUpToDate());
@@ -130,14 +140,11 @@ public class ManagedCloudSdkTest {
     Assert.assertTrue(testSdk.isUpToDate());
   }
 
-  private static final Path CLOUD_SDK_PARTIAL_PATH =
-      Paths.get("google-cloud-tools-java").resolve("managed-cloud-sdk");
+  private static final Path CLOUD_SDK_PARTIAL_PATH = Paths.get("google/ct4j-cloud-sdk");
 
   @Test
   public void testGetOsSpecificManagedSdk_windowsStandard() throws IOException {
-    Path userHome = tempDir.getRoot().toPath();
     Path localAppData = Files.createDirectories(userHome.resolve("AppData").resolve("Local"));
-    Properties fakeProperties = getFakeProperties(userHome.toString());
     Path windowsPath =
         ManagedCloudSdk.getOsSpecificManagedSdkHome(
             OsInfo.Name.WINDOWS,
@@ -149,46 +156,35 @@ public class ManagedCloudSdkTest {
 
   @Test
   public void testGetOsSpecificManagedSdk_macStandard() throws IOException {
-    Path userHome = tempDir.getRoot().toPath();
-    Properties fakeProperties = getFakeProperties(userHome.toString());
     Path expectedPath =
         Files.createDirectories(userHome.resolve("Library").resolve("Application Support"));
     Path macPath =
-        ManagedCloudSdk.getOsSpecificManagedSdkHome(
-            OsInfo.Name.MAC, fakeProperties, Collections.<String, String>emptyMap());
+        ManagedCloudSdk.getOsSpecificManagedSdkHome(OsInfo.Name.MAC, fakeProperties, EMPTY_MAP);
     Assert.assertEquals(expectedPath.resolve(CLOUD_SDK_PARTIAL_PATH), macPath);
   }
 
   @Test
   public void testGetOsSpecificManagedSdk_linuxStandard() {
-    Path userHome = tempDir.getRoot().toPath();
-    Properties fakeProperties = getFakeProperties(userHome.toString());
     Path expectedPath = userHome.resolve(".cache").resolve(CLOUD_SDK_PARTIAL_PATH);
 
     Path linuxPath =
-        ManagedCloudSdk.getOsSpecificManagedSdkHome(
-            OsInfo.Name.LINUX, fakeProperties, Collections.<String, String>emptyMap());
+        ManagedCloudSdk.getOsSpecificManagedSdkHome(OsInfo.Name.LINUX, fakeProperties, EMPTY_MAP);
     Assert.assertEquals(expectedPath, linuxPath);
   }
 
   @Test
   public void testGetOsSpecificManagedSdk_windowsFallbackLocalAppDataEnvNotSet() {
-    Path userHome = tempDir.getRoot().toPath();
-    Properties fakeProperties = getFakeProperties(userHome.toString());
     Path expectedPath = userHome.resolve(".cache").resolve(CLOUD_SDK_PARTIAL_PATH);
 
     Path windowsPath =
-        ManagedCloudSdk.getOsSpecificManagedSdkHome(
-            OsInfo.Name.WINDOWS, fakeProperties, Collections.<String, String>emptyMap());
+        ManagedCloudSdk.getOsSpecificManagedSdkHome(OsInfo.Name.WINDOWS, fakeProperties, EMPTY_MAP);
 
     Assert.assertEquals(expectedPath, windowsPath);
   }
 
   @Test
   public void testGetOsSpecificManagedSdk_windowsFallbackLocalAppDataDoesntExist() {
-    Path userHome = tempDir.getRoot().toPath();
     Path localAppData = userHome.resolve("AppData").resolve("Local"); // not created
-    Properties fakeProperties = getFakeProperties(userHome.toString());
     Path expectedPath = userHome.resolve(".cache").resolve(CLOUD_SDK_PARTIAL_PATH);
 
     Path windowsPath =
@@ -202,20 +198,11 @@ public class ManagedCloudSdkTest {
 
   @Test
   public void testGetOsSpecificManagedSdk_macFallback() {
-    Path userHome = tempDir.getRoot().toPath();
-    Properties fakeProperties = getFakeProperties(userHome.toString());
     Path expectedPath = userHome.resolve(".cache").resolve(CLOUD_SDK_PARTIAL_PATH);
 
     Path macPath =
-        ManagedCloudSdk.getOsSpecificManagedSdkHome(
-            OsInfo.Name.MAC, fakeProperties, Collections.<String, String>emptyMap());
+        ManagedCloudSdk.getOsSpecificManagedSdkHome(OsInfo.Name.MAC, fakeProperties, EMPTY_MAP);
     Assert.assertEquals(expectedPath, macPath);
-  }
-
-  private static Properties getFakeProperties(String userHome) {
-    Properties properties = new Properties();
-    properties.put("user.home", userHome);
-    return properties;
   }
 
   private void downgradeCloudSdk(ManagedCloudSdk testSdk)

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
@@ -140,7 +140,9 @@ public class ManagedCloudSdkTest {
     Assert.assertTrue(testSdk.isUpToDate());
   }
 
-  private static final Path CLOUD_SDK_PARTIAL_PATH = Paths.get("google/ct4j-cloud-sdk");
+  private static final Path CLOUD_SDK_PARTIAL_PATH =
+      Paths.get("google-cloud-tools-java/managed-cloud-sdk");
+  private static final Path CLOUD_SDK_PARTIAL_PATH_WINDOWS = Paths.get("google/ct4j-cloud-sdk");
 
   @Test
   public void testGetOsSpecificManagedSdk_windowsStandard() throws IOException {
@@ -151,7 +153,7 @@ public class ManagedCloudSdkTest {
             fakeProperties,
             ImmutableMap.of("LOCALAPPDATA", localAppData.toString()));
 
-    Assert.assertEquals(localAppData.resolve(CLOUD_SDK_PARTIAL_PATH), windowsPath);
+    Assert.assertEquals(localAppData.resolve(CLOUD_SDK_PARTIAL_PATH_WINDOWS), windowsPath);
   }
 
   @Test
@@ -174,7 +176,7 @@ public class ManagedCloudSdkTest {
 
   @Test
   public void testGetOsSpecificManagedSdk_windowsFallbackLocalAppDataEnvNotSet() {
-    Path expectedPath = userHome.resolve(".cache").resolve(CLOUD_SDK_PARTIAL_PATH);
+    Path expectedPath = userHome.resolve(".cache").resolve(CLOUD_SDK_PARTIAL_PATH_WINDOWS);
 
     Path windowsPath =
         ManagedCloudSdk.getOsSpecificManagedSdkHome(OsInfo.Name.WINDOWS, fakeProperties, EMPTY_MAP);
@@ -185,7 +187,7 @@ public class ManagedCloudSdkTest {
   @Test
   public void testGetOsSpecificManagedSdk_windowsFallbackLocalAppDataDoesntExist() {
     Path localAppData = userHome.resolve("AppData").resolve("Local"); // not created
-    Path expectedPath = userHome.resolve(".cache").resolve(CLOUD_SDK_PARTIAL_PATH);
+    Path expectedPath = userHome.resolve(".cache").resolve(CLOUD_SDK_PARTIAL_PATH_WINDOWS);
 
     Path windowsPath =
         ManagedCloudSdk.getOsSpecificManagedSdkHome(


### PR DESCRIPTION
About #595.

Reduces SDK home path length. With 20 more characters, I think we can practically get away from #595.

New: `Users\<user name>\AppData\Local\google\ct4j-cloud-sdk\LATEST\google-cloud-sdk`
Old: `Users\<user name>\AppData\Local\google-cloud-tools-java\managed-cloud-sdk\LATEST\google-cloud-sdk`

I also looked into if I could remove the last segment `google-cloud-sdk` too, but it is a bit complicated. Maybe next time if it still matters.

This will cause existing users to re-install the SDK on the new path. Because all our Cloud tools cannot be upgrade simultaneously (and even users may run multiple instances of Eclipses with different CT4E versions), we should not delete the old SDK install for some time. (For deleting in old SDK, I actually have a [working implementation](https://github.com/GoogleCloudPlatform/appengine-plugins-core/compare/i595-reduce-path-len?expand=1). To be submitted later.)