### PR TITLE
use parent pom

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -195,6 +195,17 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3</version>
+        <configuration>
+          <archive>
+            <!-- include manifest produced by maven-bundle-plugin -->
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>2.1.2</version>
         <executions>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -168,6 +168,32 @@
         </executions>
       </plugin>
       <plugin>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>8.8</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <consoleOutput>false</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <violationSeverity>warning</violationSeverity>
+          <configLocation>google_checks.xml</configLocation>
+          <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>3.0.0-M1</version>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -167,6 +167,25 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M1</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <dependencyConvergence/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </pluginManagement>
   </build>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -195,6 +195,19 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.1.2</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>3.0.0-M1</version>
         <executions>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -91,7 +91,7 @@
     </dependencies>
   </dependencyManagement>
 
-  <!-- This only works for inheritance; not import???? -->
+  <!-- This only works for inheritance, not import. -->
   <build>
     <pluginManagement>
       <plugins>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -95,12 +95,48 @@
   <build>
     <pluginManagement>
       <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.1</version>
+        <configuration>
+          <compilerId>javac-with-errorprone</compilerId>
+          <forceJavacCompilerUse>true</forceJavacCompilerUse>
+          <!-- maven-compiler-plugin defaults to targeting Java 5, but our javac
+          only supports >=6 -->
+          <source>1.8</source>
+          <target>1.8</target>
+          <showWarnings>true</showWarnings>
+          <annotationProcessorPaths>
+            <path>
+               <groupId>com.uber.nullaway</groupId>
+               <artifactId>nullaway</artifactId>
+               <version>0.4.4</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-javac-errorprone</artifactId>
+            <version>2.8.3</version>
+          </dependency>
+          <!-- override plexus-compiler-javac-errorprone's dependency on
+          Error Prone with the latest version -->
+          <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_core</artifactId>
+            <version>2.3.1</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
         <!-- for development support in Eclipse IDE -->
         <plugin>
-        <groupId>org.eclipse.m2e</groupId>
-        <artifactId>lifecycle-mapping</artifactId>
-        <version>1.0.0</version>
-        <configuration>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
           <lifecycleMappingMetadata>
             <pluginExecutions>
               <!-- m2eclipse does not support errorprone -->

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -91,4 +91,84 @@
     </dependencies>
   </dependencyManagement>
 
+  <!-- This only works for inheritance; not import???? -->
+  <build>
+    <pluginManagement>
+      <plugins>
+        <!-- for development support in Eclipse IDE -->
+        <plugin>
+        <groupId>org.eclipse.m2e</groupId>
+        <artifactId>lifecycle-mapping</artifactId>
+        <version>1.0.0</version>
+        <configuration>
+          <lifecycleMappingMetadata>
+            <pluginExecutions>
+              <!-- m2eclipse does not support errorprone -->
+              <pluginExecution>
+                <pluginExecutionFilter>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-compiler-plugin</artifactId>
+                  <versionRange>[3.3,)</versionRange>
+                  <goals>
+                    <goal>compile</goal>
+                    <goal>testCompile</goal>
+                  </goals>
+                  <parameters>
+                    <compilerId>javac-with-errorprone</compilerId>
+                  </parameters>
+                </pluginExecutionFilter>
+                <action>
+                  <configurator>
+                    <id>org.eclipse.m2e.jdt.javaConfigurator</id>
+                  </configurator>
+                </action>
+              </pluginExecution>
+              <!-- m2e does not support fmt-maven-plugin -->
+              <pluginExecution>
+                <pluginExecutionFilter>
+                  <groupId>com.coveo</groupId>
+                  <artifactId>fmt-maven-plugin</artifactId>
+                  <versionRange>[0.0,)</versionRange>
+                  <goals>
+                    <goal>check</goal>
+                  </goals>
+                </pluginExecutionFilter>
+                <action>
+                  <execute>
+                    <runOnIncremental>true</runOnIncremental>
+                  </execute>
+                </action>
+              </pluginExecution>
+            </pluginExecutions>
+          </lifecycleMappingMetadata>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>2.4.0</version>
+        <!-- use fmt:format to auto format -->
+        <dependencies>
+          <dependency>
+            <groupId>com.google.googlejavaformat</groupId>
+            <artifactId>google-java-format</artifactId>
+            <version>1.5</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <displayFiles>true</displayFiles>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>format</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </pluginManagement>
+  </build>
+
 </project>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -77,19 +77,16 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>2.18.0</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.hamcrest</groupId>
          <artifactId>hamcrest-core</artifactId>
          <version>1.3</version>
-         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.hamcrest</groupId>
          <artifactId>hamcrest-library</artifactId>
          <version>1.3</version>
-         <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -95,10 +95,10 @@
   <build>
     <pluginManagement>
       <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.1</version>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.6.1</version>
         <configuration>
           <compilerId>javac-with-errorprone</compilerId>
           <forceJavacCompilerUse>true</forceJavacCompilerUse>
@@ -269,6 +269,20 @@
                 <dependencyConvergence/>
               </rules>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.0.1</version>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.google.cloud</groupId>
+  <artifactId>parent-pom</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Google Cloud Common Parent POM</name>
+  <description>
+    A common pom for Google Cloud open source libraries.
+  </description>
+  <url>TBD</url>
+
+  <organization>
+    <name>Google Inc.</name>
+    <url>https://cloud.google.com</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>25.0-jre</version>
+      </dependency>
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>1.17</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>3.0.2</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>2.7</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish</groupId>
+        <artifactId>javax.json</artifactId>
+        <version>1.0.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>1.14</version>
+      </dependency>
+
+      <!-- test dependencies -->
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.12</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>2.18.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.hamcrest</groupId>
+         <artifactId>hamcrest-core</artifactId>
+         <version>1.3</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.hamcrest</groupId>
+         <artifactId>hamcrest-library</artifactId>
+         <version>1.3</version>
+         <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -159,46 +159,17 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.1</version>
         <configuration>
-          <compilerId>javac-with-errorprone</compilerId>
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-          <!-- maven-compiler-plugin defaults to targeting Java 5, but our javac
-          only supports >=6 -->
-          <source>1.8</source>
-          <target>1.8</target>
-          <showWarnings>true</showWarnings>
-          <annotationProcessorPaths>
-            <path>
-               <groupId>com.uber.nullaway</groupId>
-               <artifactId>nullaway</artifactId>
-               <version>0.4.4</version>
-            </path>
-          </annotationProcessorPaths>
           <compilerArgs>
             <arg>-Xep:NullAway:ERROR</arg>    
             <arg>-XepOpt:NullAway:AnnotatedPackages=com.google.cloud.tools.appengine,com.google.cloud.tools.libraries,com.google.cloud.tools.managedcloudsdk,com.google.cloud.tools.io,com.google.cloud.tools.project</arg>
-            <arg>-XepOpt:NullAway:UnannotatedSubPackages=com.google.cloud.tools.appengine.cloudsdk.[a-zA-Z.]*</arg>
+<arg>-XepOpt:NullAway:UnannotatedSubPackages=com.google.cloud.tools.appengine.cloudsdk.[a-zA-Z.]*</arg>
 <arg>-XepOpt:NullAway:ExcludedFieldAnnotations=org.mockito.Mock,org.junit.runners.Parameterized</arg>
 <arg>-XepOpt:NullAway:ExcludedClasses=com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer1Test,com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer2Test,com.google.cloud.tools.managedcloudsdk.install.InstallerFactoryTest,com.google.cloud.tools.appengine.AppEngineDescriptorTest</arg>
 <arg>-XepOpt:NullAway:KnownInitializers=com.google.gson.Gson.fromJson</arg>
 
           </compilerArgs>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>2.8.3</version>
-          </dependency>
-          <!-- override plexus-compiler-javac-errorprone's dependency on
-          Error Prone with the latest version -->
-          <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <version>2.3.1</version>
-          </dependency>
-        </dependencies>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -235,29 +235,6 @@
 
       <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.17</version>
-        <dependencies>
-          <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>8.8</version>
-          </dependency>
-        </dependencies>
-        <configuration>
-          <consoleOutput>false</consoleOutput>
-          <failOnViolation>true</failOnViolation>
-          <violationSeverity>warning</violationSeverity>
-          <configLocation>google_checks.xml</configLocation>
-          <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -306,24 +306,8 @@
        <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M1</version>
-        <executions>
-          <execution>
-            <id>enforce</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <dependencyConvergence/>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
-
   </build>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,13 @@
                              http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath>parent-pom/pom.xml</relativePath>
+  </parent>
+
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>appengine-plugins-core</artifactId>
   <version>0.6.1-SNAPSHOT</version>
@@ -80,58 +87,48 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>21.0</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.17</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>javax.json</artifactId>
-      <version>1.0.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.14</version>
     </dependency>
 
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.18.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
        <groupId>org.hamcrest</groupId>
        <artifactId>hamcrest-core</artifactId>
-       <version>1.3</version>
        <scope>test</scope>
     </dependency>
     <dependency>
        <groupId>org.hamcrest</groupId>
        <artifactId>hamcrest-library</artifactId>
-       <version>1.3</version>
        <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -216,15 +216,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.1.2</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <!-- use fmt:format to auto format -->

--- a/pom.xml
+++ b/pom.xml
@@ -204,13 +204,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.3</version>
-        <configuration>
-          <archive>
-            <!-- include manifest produced by maven-bundle-plugin -->
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-          </archive>
-        </configuration>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.0.1</version>
         <configuration>
           <!--
              Register as an Eclipse Buddy to allow discovery of CloudSdkResolver
@@ -212,15 +211,6 @@
             <Bundle-DocURL>https://github.com/GoogleCloudPlatform/appengine-plugins-core</Bundle-DocURL>
           </instructions>
         </configuration>
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,10 @@
 
   <!-- import the parent POM/BOM. -->
   <!-- For now this requires first installing the parent POM locally
-       with `mvn clean install`. -->
+       with `mvn clean install`. This only sets dependency versions.
+       It does not provide plugin configuration. That must be done in
+       the parent POM. We could separate depedency versions into a BOM
+       and pluginManagement in a parent POM. -->
   <!--
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -224,29 +224,10 @@
         </executions>
       </plugin>
 
+      <!-- use fmt:format to auto format -->
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.4.0</version>
-        <!-- use fmt:format to auto format -->
-        <dependencies>
-          <dependency>
-            <groupId>com.google.googlejavaformat</groupId>
-            <artifactId>google-java-format</artifactId>
-            <version>1.5</version>
-          </dependency>
-        </dependencies>
-        <configuration>
-          <displayFiles>true</displayFiles>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>validate</phase>
-            <goals>
-              <goal>format</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
@@ -339,59 +320,6 @@
         </executions>
       </plugin>
     </plugins>
-
-    <pluginManagement>
-      <plugins>
-        <!-- for development support in Eclipse IDE -->
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <!-- m2eclipse does not support errorprone -->
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <versionRange>[3.3,)</versionRange>
-                    <goals>
-                      <goal>compile</goal>
-                      <goal>testCompile</goal>
-                    </goals>
-                    <parameters>
-                      <compilerId>javac-with-errorprone</compilerId>
-                    </parameters>
-                  </pluginExecutionFilter>
-                  <action>
-                    <configurator>
-                      <id>org.eclipse.m2e.jdt.javaConfigurator</id>
-                    </configurator>
-                  </action>
-                </pluginExecution>
-                <!-- m2e does not support fmt-maven-plugin -->
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>com.coveo</groupId>
-                    <artifactId>fmt-maven-plugin</artifactId>
-                    <versionRange>[0.0,)</versionRange>
-                    <goals>
-                      <goal>check</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <execute>
-                      <runOnIncremental>true</runOnIncremental>
-                    </execute>
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
 
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,11 @@
                              http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <groupId>com.google.cloud.tools</groupId>
+  <artifactId>appengine-plugins-core</artifactId>
+  <version>0.6.1-SNAPSHOT</version>
+
+  <!-- inherit the parent POM/BOM -->
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>parent-pom</artifactId>
@@ -12,9 +17,22 @@
     <relativePath>parent-pom/pom.xml</relativePath>
   </parent>
 
-  <groupId>com.google.cloud.tools</groupId>
-  <artifactId>appengine-plugins-core</artifactId>
-  <version>0.6.1-SNAPSHOT</version>
+  <!-- import the parent POM/BOM. -->
+  <!-- For now this requires first installing the parent POM locally
+       with `mvn clean install`. -->
+  <!--
+  <dependencyManagement>
+    <dependencies>
+     <dependency>
+       <groupId>com.google.cloud</groupId>
+       <artifactId>parent-pom</artifactId>
+       <version>0.0.1-SNAPSHOT</version>
+       <type>pom</type>
+       <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  -->
 
   <name>App Engine Plugins Core Library</name>
   <description>


### PR DESCRIPTION
@loosebazooka @patflynn Not really intended for checkin. Just an example of what a parent pom/BOM might look like.

If this were in a separate repo (as it should be) it would need to be pushed there before it could be updated here and in other clients.

Technically this is being used as a parent by inheritance. If we import it instead, it's a BOM. Either way the same pom.xml file is used. 

http://www.baeldung.com/spring-maven-bom has a good description. Quoting from there, order of precedence is:

1. The version of the artifact’s direct declaration in our project pom
2. The version of the artifact in the parent project
3. The version in the imported pom, taking into consideration the order of importing files
4. Dependency mediation

We can overwrite the artifact’s version by explicitly defining the artifact in our project’s pom with the desired version

If the same artifact is defined with different versions in 2 imported BOMs, then the version in the BOM file that was declared first will win.

Plugin configuration, however, can only be done in an inherited parent POM, not in a BOM. We can have both.