### PR TITLE
Fix nullability for JSON parsing

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResult.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResult.java
@@ -79,7 +79,7 @@ public class AppEngineDeployResult {
     try {
       AppEngineDeployResult fromJson = new Gson().fromJson(jsonString, AppEngineDeployResult.class);
       if (fromJson == null) {
-        throw new JsonParseException("Empty JSON: \"" + jsonString + "\"");
+        throw new JsonParseException("Empty input: \"" + jsonString + "\"");
       }
       if (fromJson.versions == null) {
         throw new JsonParseException("Missing version");

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResult.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResult.java
@@ -78,6 +78,9 @@ public class AppEngineDeployResult {
     Preconditions.checkNotNull(jsonString);
     try {
       AppEngineDeployResult fromJson = new Gson().fromJson(jsonString, AppEngineDeployResult.class);
+      if (fromJson == null) {
+        throw new JsonParseException("Empty JSON: \"" + jsonString + "\"");
+      }
       if (fromJson.versions == null) {
         throw new JsonParseException("Missing version");
       }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLog.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLog.java
@@ -91,7 +91,7 @@ public class GcloudStructuredLog {
     try {
       GcloudStructuredLog log = new Gson().fromJson(jsonString, GcloudStructuredLog.class);
       if (log == null) {
-        throw new JsonParseException("Empty or invalid JSON: \"" + jsonString + "\"");
+        throw new JsonParseException("Empty input: \"" + jsonString + "\"");
       }
       return log;
     } catch (JsonSyntaxException e) {

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLog.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLog.java
@@ -89,7 +89,11 @@ public class GcloudStructuredLog {
   public static GcloudStructuredLog parse(String jsonString) throws JsonParseException {
     Preconditions.checkNotNull(jsonString);
     try {
-      return new Gson().fromJson(jsonString, GcloudStructuredLog.class);
+      GcloudStructuredLog log = new Gson().fromJson(jsonString, GcloudStructuredLog.class);
+      if (log == null) {
+        throw new JsonParseException("Empty or invalid JSON: \"" + jsonString + "\"");
+      }
+      return log;
     } catch (JsonSyntaxException e) {
       throw new JsonParseException(e);
     }

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResultTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResultTest.java
@@ -84,22 +84,22 @@ public class AppEngineDeployResultTest {
   }
 
   @Test
-  public void testParse_emptyString() {
+  public void testParse_emptyInput() {
     try {
       AppEngineDeployResult.parse("");
       fail();
     } catch (JsonParseException e) {
-      assertEquals("Empty JSON: \"\"", e.getMessage());
+      assertEquals("Empty input: \"\"", e.getMessage());
     }
   }
 
   @Test
-  public void testParse_effectivelyEmpty() {
+  public void testParse_effectivelyEmptyInput() {
     try {
       AppEngineDeployResult.parse("# comment?");
       fail();
     } catch (JsonParseException e) {
-      assertEquals("Empty JSON: \"# comment?\"", e.getMessage());
+      assertEquals("Empty input: \"# comment?\"", e.getMessage());
     }
   }
 

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResultTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResultTest.java
@@ -15,10 +15,11 @@
 package com.google.cloud.tools.appengine.cloudsdk.serialization;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.cloud.tools.appengine.cloudsdk.JsonParseException;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -83,12 +84,32 @@ public class AppEngineDeployResultTest {
   }
 
   @Test
+  public void testParse_emptyString() {
+    try {
+      AppEngineDeployResult.parse("");
+      fail();
+    } catch (JsonParseException e) {
+      assertEquals("Empty JSON: \"\"", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testParse_effectivelyEmpty() {
+    try {
+      AppEngineDeployResult.parse("# comment?");
+      fail();
+    } catch (JsonParseException e) {
+      assertEquals("Empty JSON: \"# comment?\"", e.getMessage());
+    }
+  }
+
+  @Test
   public void testParse_malformedInput() {
     try {
       AppEngineDeployResult.parse("non-JSON");
       fail();
     } catch (JsonParseException e) {
-      assertNotNull(e.getMessage());
+      assertThat(e.getMessage(), CoreMatchers.containsString("JsonSyntaxException"));
     }
   }
 
@@ -98,7 +119,7 @@ public class AppEngineDeployResultTest {
       AppEngineDeployResult.parse("{ 'versions' : 'non-array' }");
       fail();
     } catch (JsonParseException e) {
-      assertNotNull(e.getMessage());
+      assertThat(e.getMessage(), CoreMatchers.containsString("JsonSyntaxException"));
     }
   }
 

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLogTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLogTest.java
@@ -72,22 +72,22 @@ public class GcloudStructuredLogTest {
   }
 
   @Test
-  public void testParse_emptyString() {
+  public void testParse_emptyInput() {
     try {
-      AppEngineDeployResult.parse("");
+      GcloudStructuredLog.parse("");
       fail();
     } catch (JsonParseException e) {
-      assertEquals("Empty JSON: \"\"", e.getMessage());
+      assertEquals("Empty input: \"\"", e.getMessage());
     }
   }
 
   @Test
-  public void testParse_effectivelyEmpty() {
+  public void testParse_effectivelyEmptyInput() {
     try {
-      AppEngineDeployResult.parse("# comment?");
+      GcloudStructuredLog.parse("# comment?");
       fail();
     } catch (JsonParseException e) {
-      assertEquals("Empty JSON: \"# comment?\"", e.getMessage());
+      assertEquals("Empty input: \"# comment?\"", e.getMessage());
     }
   }
 

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLogTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLogTest.java
@@ -71,6 +71,26 @@ public class GcloudStructuredLogTest {
   }
 
   @Test
+  public void testParse_emptyString() {
+    try {
+      AppEngineDeployResult.parse("");
+      fail();
+    } catch (JsonParseException e) {
+      assertEquals("Empty JSON: \"\"", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testParse_effectivelyEmpty() {
+    try {
+      AppEngineDeployResult.parse("# comment?");
+      fail();
+    } catch (JsonParseException e) {
+      assertEquals("Empty JSON: \"# comment?\"", e.getMessage());
+    }
+  }
+
+  @Test
   public void testParse_inputMalformed() {
     try {
       GcloudStructuredLog.parse("non-JSON");

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLogTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/GcloudStructuredLogTest.java
@@ -17,11 +17,12 @@
 package com.google.cloud.tools.appengine.cloudsdk.serialization;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.cloud.tools.appengine.cloudsdk.JsonParseException;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 public class GcloudStructuredLogTest {
@@ -96,7 +97,7 @@ public class GcloudStructuredLogTest {
       GcloudStructuredLog.parse("non-JSON");
       fail();
     } catch (JsonParseException e) {
-      assertNotNull(e.getMessage());
+      assertThat(e.getMessage(), CoreMatchers.containsString("JsonSyntaxException"));
     }
   }
 


### PR DESCRIPTION
Our Javadoc:
```
    * Parses a JSON string representing successful {@code gcloud app deploy} result.
    *
    * @return parsed JSON; never {@code null}
```

However, it turns out `Gson().fromJson()` does return null for empty JSON (not documented in the GSON Javadoc).