### PR TITLE
Fix DownloaderTest

### DIFF
--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkTest.java
@@ -30,6 +30,7 @@ import com.google.cloud.tools.appengine.api.AppEngineException;
 import com.google.common.io.Files;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -53,7 +54,7 @@ public class CloudSdkTest {
   }
 
   private void writeVersionFile(String contents) throws IOException {
-    Files.write(contents, root.resolve("VERSION").toFile(), Charset.defaultCharset());
+    Files.write(contents, root.resolve("VERSION").toFile(), StandardCharsets.UTF_8);
   }
 
   @Test

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/DownloaderTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/DownloaderTest.java
@@ -167,7 +167,7 @@ public class DownloaderTest {
 
     // Start a new thread for this test to avoid mucking with Thread state when
     // junit reuses threads.
-    Future<Void> submit =
+    Future<Void> testThreadToInterrupt =
         Executors.newSingleThreadExecutor()
             .submit(
                 new Callable<Void>() {
@@ -186,7 +186,7 @@ public class DownloaderTest {
                     return null;
                   }
                 });
-    submit.get();
+    testThreadToInterrupt.get();
 
     Assert.assertFalse(Files.exists(destination));
     Mockito.verify(mockProgressListener, Mockito.never()).update(100);


### PR DESCRIPTION
Fixes #626. (`Future.get()` is a blocking call, FYI.)

Also changing to always use UTF-8. What `Charset.defaultCharset()` returns is platform-dependent.