### PR TITLE
Make validateJdk public

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -215,7 +215,7 @@ public class CloudSdk {
     }
   }
 
-  void validateJdk() throws InvalidJavaSdkException {
+  public void validateJdk() throws InvalidJavaSdkException {
     if (!Files.exists(getJavaExecutablePath())) {
       throw new InvalidJavaSdkException(
           "Invalid Java SDK. " + getJavaExecutablePath().toString() + " does not exist.");

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -215,6 +215,11 @@ public class CloudSdk {
     }
   }
 
+  /**
+   * Checks whether the configured Java home path is a valid JDK.
+   *
+   * @see #getJavaHomePath()
+   */
   public void validateJdk() throws InvalidJavaSdkException {
     if (!Files.exists(getJavaExecutablePath())) {
       throw new InvalidJavaSdkException(


### PR DESCRIPTION
I've missed the discussion about making it public when we decided to remove the check from `validateCloudSdk()` in #442.