### PR TITLE
Use JaCoCo instead of cobertura

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ script:
     else
       mvn clean install -B -U
     fi
-  - mvn cobertura:cobertura
 
 env:
   global:

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
             </path>
           </annotationProcessorPaths>
           <compilerArgs>
-            <arg>-Xep:NullAway:ERROR</arg>    
+            <arg>-Xep:NullAway:ERROR</arg>
             <arg>-XepOpt:NullAway:AnnotatedPackages=com.google.cloud.tools.appengine,com.google.cloud.tools.libraries,com.google.cloud.tools.managedcloudsdk,com.google.cloud.tools.io,com.google.cloud.tools.project</arg>
             <arg>-XepOpt:NullAway:UnannotatedSubPackages=com.google.cloud.tools.appengine.cloudsdk.[a-zA-Z.]*</arg>
 <arg>-XepOpt:NullAway:ExcludedFieldAnnotations=org.mockito.Mock,org.junit.runners.Parameterized</arg>
@@ -275,7 +275,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Import-Package>!javax.annotation,*</Import-Package>
             <Eclipse-BuddyPolicy>registered</Eclipse-BuddyPolicy>
-            <!--  best URL we have until 
+            <!--  best URL we have until
                   https://github.com/GoogleCloudPlatform/appengine-plugins-core/issues/338
                   is fixed -->
             <Bundle-DocURL>https://github.com/GoogleCloudPlatform/appengine-plugins-core</Bundle-DocURL>
@@ -292,18 +292,20 @@
         </executions>
       </plugin>
 
+      <!-- set up surefire for JaCoCo code coverage -->
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <formats>
-            <format>html</format>
-            <format>xml</format>
-          </formats>
-          <check />
-        </configuration>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
        </plugin>
+
        <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -405,5 +407,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -299,8 +299,16 @@
         <version>0.8.1</version>
         <executions>
           <execution>
+            <id>initialize</id>
             <goals>
               <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>generation</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Fixes #623 

JaCoCo runs automatically on `mvn verify`, producing a binary report in `target/jacoco.exec`.

JaCoCo can be configured to fail the build if minimum requirements aren't met.

HTML reports can then be produced with `mvn jacoco:report`, put in `target/site/jacoco/jacoco-sessions.html`

<img width="1019" alt="screen shot 2018-05-22 at 11 32 08 am" src="https://user-images.githubusercontent.com/202851/40372968-d3b683c4-5db3-11e8-8ff6-fef5bd20c4af.PNG">