### PR TITLE
Fix charset warning in test class

### DIFF
--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/command/AsyncByteConsumerTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/command/AsyncByteConsumerTest.java
@@ -82,7 +82,9 @@ public class AsyncByteConsumerTest {
     int count = bytes.getAllValues().size();
     StringBuilder result = new StringBuilder();
     for (int i = 0; i < count; i++) {
-      result.append(new String(bytes.getAllValues().get(i), 0, nBytes.getAllValues().get(i)));
+      byte[] rawBytes = bytes.getAllValues().get(i);
+      int length = nBytes.getAllValues().get(i);
+      result.append(new String(rawBytes, 0, length, StandardCharsets.UTF_8));
     }
     Assert.assertEquals(TEST_STRING, result.toString());
 


### PR DESCRIPTION
```
[DefaultCharset] Implicit use of the platform default charset, which can result in differing behaviour between JVM executions or incorrect behavior if the encoding of the data source doesn't match expectations.
    (see http://errorprone.info/bugpattern/DefaultCharset)
  Did you mean 'result.append(new String(bytes.getAllValues().get(i), 0, nBytes.getAllValues().get(i), UTF_8));' or 'result.append(new String(bytes.getAllValues().get(i), 0, nBytes.getAllValues().get(i), Charset.defaultCharset()));'?
```