### PR TITLE
Set root as working directory when updating Cloud SDK

### DIFF
--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
@@ -60,7 +60,7 @@ public class ManagedCloudSdk {
   }
 
   /** Returns a path to gcloud executable (operating system specific). */
-  public Path getGcloud() {
+  public Path getGcloudPath() {
     return getSdkHome()
         .resolve("bin")
         .resolve(osInfo.name().equals(WINDOWS) ? "gcloud.cmd" : "gcloud");
@@ -75,7 +75,7 @@ public class ManagedCloudSdk {
     if (!Files.isDirectory(getSdkHome())) {
       return false;
     }
-    if (!Files.isRegularFile(getGcloud())) {
+    if (!Files.isRegularFile(getGcloudPath())) {
       return false;
     }
     // Verify the versions match up for fixed version installs
@@ -104,13 +104,13 @@ public class ManagedCloudSdk {
    * network accesses.
    */
   public boolean hasComponent(SdkComponent component) throws ManagedSdkVerificationException {
-    if (!Files.isRegularFile(getGcloud())) {
+    if (!Files.isRegularFile(getGcloudPath())) {
       return false;
     }
 
     List<String> listComponentCommand =
         Arrays.asList(
-            getGcloud().toString(),
+            getGcloudPath().toString(),
             "components",
             "list",
             "--only-local-state",
@@ -132,7 +132,7 @@ public class ManagedCloudSdk {
 
   /** Query gcloud to see if SDK is up to date. Gcloud makes a call to the server to check this. */
   public boolean isUpToDate() throws ManagedSdkVerificationException {
-    if (!Files.isRegularFile(getGcloud())) {
+    if (!Files.isRegularFile(getGcloudPath())) {
       return false;
     }
 
@@ -142,7 +142,7 @@ public class ManagedCloudSdk {
 
     List<String> updateAvailableCommand =
         Arrays.asList(
-            getGcloud().toString(),
+            getGcloudPath().toString(),
             "components",
             "list",
             "--format=json",
@@ -171,7 +171,7 @@ public class ManagedCloudSdk {
   }
 
   public SdkComponentInstaller newComponentInstaller() {
-    return SdkComponentInstaller.newComponentInstaller(osInfo.name(), getGcloud());
+    return SdkComponentInstaller.newComponentInstaller(osInfo.name(), getGcloudPath());
   }
 
   /**
@@ -184,7 +184,7 @@ public class ManagedCloudSdk {
     if (version != Version.LATEST) {
       throw new UnsupportedOperationException("Cannot update a fixed version SDK.");
     }
-    return SdkUpdater.newUpdater(osInfo.name(), getGcloud());
+    return SdkUpdater.newUpdater(osInfo.name(), getGcloudPath());
   }
 
   /** Get a new {@link ManagedCloudSdk} instance for @{link Version} specified. */

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstaller.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstaller.java
@@ -65,9 +65,10 @@ public class SdkComponentInstaller {
       environment = pythonCopier.copyPython();
     }
 
+    Path workingDirectory = gcloud.getRoot();
     List<String> command =
         Arrays.asList(gcloud.toString(), "components", "install", component.toString(), "--quiet");
-    commandRunner.run(command, null, environment, consoleListener);
+    commandRunner.run(command, workingDirectory, environment, consoleListener);
     progressListener.done();
   }
 

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstaller.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstaller.java
@@ -34,15 +34,16 @@ import javax.annotation.Nullable;
 /** Install an SDK component. */
 public class SdkComponentInstaller {
 
-  private final Path gcloud;
+  private final Path gcloudPath;
   private final CommandRunner commandRunner;
   @Nullable private final BundledPythonCopier pythonCopier;
 
   /** Use {@link #newComponentInstaller} to instantiate. */
   @VisibleForTesting
   SdkComponentInstaller(
-      Path gcloud, CommandRunner commandRunner, @Nullable BundledPythonCopier pythonCopier) {
-    this.gcloud = Preconditions.checkNotNull(gcloud);
+      Path gcloudPath, CommandRunner commandRunner, @Nullable BundledPythonCopier pythonCopier) {
+    Preconditions.checkArgument(gcloudPath.isAbsolute());
+    this.gcloudPath = Preconditions.checkNotNull(gcloudPath);
     this.commandRunner = Preconditions.checkNotNull(commandRunner);
     this.pythonCopier = pythonCopier;
   }
@@ -65,9 +66,10 @@ public class SdkComponentInstaller {
       environment = pythonCopier.copyPython();
     }
 
-    Path workingDirectory = gcloud.getRoot();
+    Path workingDirectory = gcloudPath.getRoot();
     List<String> command =
-        Arrays.asList(gcloud.toString(), "components", "install", component.toString(), "--quiet");
+        Arrays.asList(
+            gcloudPath.toString(), "components", "install", component.toString(), "--quiet");
     commandRunner.run(command, workingDirectory, environment, consoleListener);
     progressListener.done();
   }
@@ -75,18 +77,18 @@ public class SdkComponentInstaller {
   /**
    * Configure and create a new Component Installer instance.
    *
-   * @param gcloud full path to gcloud in the Cloud SDK
+   * @param gcloudPath full path to gcloud in the Cloud SDK
    * @return a new configured Cloud SDK component installer
    */
-  public static SdkComponentInstaller newComponentInstaller(OsInfo.Name osName, Path gcloud) {
+  public static SdkComponentInstaller newComponentInstaller(OsInfo.Name osName, Path gcloudPath) {
     switch (osName) {
       case WINDOWS:
         return new SdkComponentInstaller(
-            gcloud,
+            gcloudPath,
             CommandRunner.newRunner(),
-            new WindowsBundledPythonCopier(gcloud, CommandCaller.newCaller()));
+            new WindowsBundledPythonCopier(gcloudPath, CommandCaller.newCaller()));
       default:
-        return new SdkComponentInstaller(gcloud, CommandRunner.newRunner(), null);
+        return new SdkComponentInstaller(gcloudPath, CommandRunner.newRunner(), null);
     }
   }
 }

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkUpdater.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkUpdater.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.managedcloudsdk.command.CommandCaller;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExecutionException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExitException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandRunner;
+import com.google.common.base.Preconditions;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -32,12 +33,14 @@ import javax.annotation.Nullable;
 /** Update an SDK. */
 public class SdkUpdater {
 
-  private final Path gcloud;
+  private final Path gcloudPath;
   private final CommandRunner commandRunner;
   @Nullable private final BundledPythonCopier pythonCopier;
 
-  SdkUpdater(Path gcloud, CommandRunner commandRunner, @Nullable BundledPythonCopier pythonCopier) {
-    this.gcloud = gcloud;
+  SdkUpdater(
+      Path gcloudPath, CommandRunner commandRunner, @Nullable BundledPythonCopier pythonCopier) {
+    Preconditions.checkArgument(gcloudPath.isAbsolute());
+    this.gcloudPath = gcloudPath;
     this.commandRunner = commandRunner;
     this.pythonCopier = pythonCopier;
   }
@@ -57,8 +60,8 @@ public class SdkUpdater {
       environment = pythonCopier.copyPython();
     }
 
-    Path workingDirectory = gcloud.getRoot();
-    List<String> command = Arrays.asList(gcloud.toString(), "components", "update", "--quiet");
+    Path workingDirectory = gcloudPath.getRoot();
+    List<String> command = Arrays.asList(gcloudPath.toString(), "components", "update", "--quiet");
     commandRunner.run(command, workingDirectory, environment, consoleListener);
     progressListener.done();
   }
@@ -66,18 +69,18 @@ public class SdkUpdater {
   /**
    * Configure and create a new Updater instance.
    *
-   * @param gcloud path to gcloud in the Cloud SDK
+   * @param gcloudPath path to gcloud in the Cloud SDK
    * @return a new configured Cloud SDK updater
    */
-  public static SdkUpdater newUpdater(OsInfo.Name osName, Path gcloud) {
+  public static SdkUpdater newUpdater(OsInfo.Name osName, Path gcloudPath) {
     switch (osName) {
       case WINDOWS:
         return new SdkUpdater(
-            gcloud,
+            gcloudPath,
             CommandRunner.newRunner(),
-            new WindowsBundledPythonCopier(gcloud, CommandCaller.newCaller()));
+            new WindowsBundledPythonCopier(gcloudPath, CommandCaller.newCaller()));
       default:
-        return new SdkUpdater(gcloud, CommandRunner.newRunner(), null);
+        return new SdkUpdater(gcloudPath, CommandRunner.newRunner(), null);
     }
   }
 }

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkUpdater.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkUpdater.java
@@ -57,8 +57,9 @@ public class SdkUpdater {
       environment = pythonCopier.copyPython();
     }
 
+    Path workingDirectory = gcloud.getRoot();
     List<String> command = Arrays.asList(gcloud.toString(), "components", "update", "--quiet");
-    commandRunner.run(command, null, environment, consoleListener);
+    commandRunner.run(command, workingDirectory, environment, consoleListener);
     progressListener.done();
   }
 

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
@@ -212,12 +212,12 @@ public class ManagedCloudSdkTest {
           UnsupportedOsException {
     Map<String, String> env = null;
     if (OsInfo.getSystemOsInfo().name().equals(OsInfo.Name.WINDOWS)) {
-      env = WindowsBundledPythonCopierTestHelper.newInstance(testSdk.getGcloud()).copyPython();
+      env = WindowsBundledPythonCopierTestHelper.newInstance(testSdk.getGcloudPath()).copyPython();
     }
     CommandRunner.newRunner()
         .run(
             Arrays.asList(
-                testSdk.getGcloud().toString(),
+                testSdk.getGcloudPath().toString(),
                 "components",
                 "update",
                 "--quiet",

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstallerTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstallerTest.java
@@ -43,13 +43,13 @@ public class SdkComponentInstallerTest {
   @Mock private BundledPythonCopier mockBundledPythonCopier;
   @Mock private Map<String, String> mockPythonEnv;
 
-  private Path fakeGcloud;
+  private Path fakeGcloudPath;
   private SdkComponent testComponent = SdkComponent.APP_ENGINE_JAVA;
 
   @Before
   public void setUpMocks()
       throws InterruptedException, CommandExitException, CommandExecutionException {
-    fakeGcloud = Paths.get("my/path/to/fake-gcloud");
+    fakeGcloudPath = Paths.get("/my/path/to/fake-gcloud");
     Mockito.when(mockBundledPythonCopier.copyPython()).thenReturn(mockPythonEnv);
   }
 
@@ -57,7 +57,7 @@ public class SdkComponentInstallerTest {
   public void testInstallComponent_successRun()
       throws InterruptedException, CommandExitException, CommandExecutionException {
     SdkComponentInstaller testInstaller =
-        new SdkComponentInstaller(fakeGcloud, mockCommandRunner, null);
+        new SdkComponentInstaller(fakeGcloudPath, mockCommandRunner, null);
     testInstaller.installComponent(testComponent, mockProgressListener, mockConsoleListener);
     Mockito.verify(mockProgressListener).start(Mockito.anyString(), Mockito.eq(-1L));
     Mockito.verify(mockProgressListener).done();
@@ -73,7 +73,7 @@ public class SdkComponentInstallerTest {
   public void testInstallComponent_withBundledPythonCopier()
       throws InterruptedException, CommandExitException, CommandExecutionException {
     SdkComponentInstaller testInstaller =
-        new SdkComponentInstaller(fakeGcloud, mockCommandRunner, mockBundledPythonCopier);
+        new SdkComponentInstaller(fakeGcloudPath, mockCommandRunner, mockBundledPythonCopier);
     testInstaller.installComponent(testComponent, mockProgressListener, mockConsoleListener);
     Mockito.verify(mockProgressListener).start(Mockito.anyString(), Mockito.eq(-1L));
     Mockito.verify(mockProgressListener).done();
@@ -89,18 +89,18 @@ public class SdkComponentInstallerTest {
   public void testInstallComponent_workingDirectorySet()
       throws InterruptedException, CommandExitException, CommandExecutionException {
     SdkComponentInstaller testInstaller =
-        new SdkComponentInstaller(fakeGcloud, mockCommandRunner, null);
+        new SdkComponentInstaller(fakeGcloudPath, mockCommandRunner, null);
     testInstaller.installComponent(testComponent, mockProgressListener, mockConsoleListener);
     Mockito.verify(mockCommandRunner)
         .run(
             Mockito.anyList(),
-            Mockito.eq(fakeGcloud.getRoot()),
+            Mockito.eq(fakeGcloudPath.getRoot()),
             Mockito.<Map<String, String>>any(),
             Mockito.any(ConsoleListener.class));
   }
 
   private List<String> expectedCommand() {
     return Arrays.asList(
-        fakeGcloud.toString(), "components", "install", testComponent.toString(), "--quiet");
+        fakeGcloudPath.toString(), "components", "install", testComponent.toString(), "--quiet");
   }
 }

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstallerTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstallerTest.java
@@ -61,7 +61,12 @@ public class SdkComponentInstallerTest {
     testInstaller.installComponent(testComponent, mockProgressListener, mockConsoleListener);
     Mockito.verify(mockProgressListener).start(Mockito.anyString(), Mockito.eq(-1L));
     Mockito.verify(mockProgressListener).done();
-    Mockito.verify(mockCommandRunner).run(expectedCommand(), null, null, mockConsoleListener);
+    Mockito.verify(mockCommandRunner)
+        .run(
+            Mockito.eq(expectedCommand()),
+            Mockito.nullable(Path.class),
+            Mockito.<Map<String, String>>any(),
+            Mockito.eq(mockConsoleListener));
   }
 
   @Test
@@ -73,7 +78,25 @@ public class SdkComponentInstallerTest {
     Mockito.verify(mockProgressListener).start(Mockito.anyString(), Mockito.eq(-1L));
     Mockito.verify(mockProgressListener).done();
     Mockito.verify(mockCommandRunner)
-        .run(expectedCommand(), null, mockPythonEnv, mockConsoleListener);
+        .run(
+            Mockito.eq(expectedCommand()),
+            Mockito.nullable(Path.class),
+            Mockito.eq(mockPythonEnv),
+            Mockito.eq(mockConsoleListener));
+  }
+
+  @Test
+  public void testInstallComponent_workingDirectorySet()
+      throws InterruptedException, CommandExitException, CommandExecutionException {
+    SdkComponentInstaller testInstaller =
+        new SdkComponentInstaller(fakeGcloud, mockCommandRunner, null);
+    testInstaller.installComponent(testComponent, mockProgressListener, mockConsoleListener);
+    Mockito.verify(mockCommandRunner)
+        .run(
+            Mockito.anyList(),
+            Mockito.eq(fakeGcloud.getRoot()),
+            Mockito.<Map<String, String>>any(),
+            Mockito.any(ConsoleListener.class));
   }
 
   private List<String> expectedCommand() {

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstallerTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstallerTest.java
@@ -21,8 +21,8 @@ import com.google.cloud.tools.managedcloudsdk.ProgressListener;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExecutionException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExitException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandRunner;
+import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +49,8 @@ public class SdkComponentInstallerTest {
   @Before
   public void setUpMocks()
       throws InterruptedException, CommandExitException, CommandExecutionException {
-    fakeGcloudPath = Paths.get("/my/path/to/fake-gcloud");
+    Path root = FileSystems.getDefault().getRootDirectories().iterator().next();
+    fakeGcloudPath = root.resolve("my/path/to/fake-gcloud");
     Mockito.when(mockBundledPythonCopier.copyPython()).thenReturn(mockPythonEnv);
   }
 

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/components/SdkUpdaterTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/components/SdkUpdaterTest.java
@@ -59,7 +59,12 @@ public class SdkUpdaterTest {
     testUpdater.update(mockProgressListener, mockConsoleListener);
     Mockito.verify(mockProgressListener).start(Mockito.anyString(), Mockito.eq(-1L));
     Mockito.verify(mockProgressListener).done();
-    Mockito.verify(mockCommandRunner).run(expectedCommand(), null, null, mockConsoleListener);
+    Mockito.verify(mockCommandRunner)
+        .run(
+            Mockito.eq(expectedCommand()),
+            Mockito.nullable(Path.class),
+            Mockito.<Map<String, String>>any(),
+            Mockito.eq(mockConsoleListener));
   }
 
   @Test
@@ -70,7 +75,24 @@ public class SdkUpdaterTest {
     Mockito.verify(mockProgressListener).start(Mockito.anyString(), Mockito.eq(-1L));
     Mockito.verify(mockProgressListener).done();
     Mockito.verify(mockCommandRunner)
-        .run(expectedCommand(), null, mockPythonEnv, mockConsoleListener);
+        .run(
+            Mockito.eq(expectedCommand()),
+            Mockito.nullable(Path.class),
+            Mockito.eq(mockPythonEnv),
+            Mockito.eq(mockConsoleListener));
+  }
+
+  @Test
+  public void testInstallComponent_workingDirectorySet()
+      throws InterruptedException, CommandExitException, CommandExecutionException {
+    SdkUpdater testUpdater = new SdkUpdater(fakeGcloud, mockCommandRunner, null);
+    testUpdater.update(mockProgressListener, mockConsoleListener);
+    Mockito.verify(mockCommandRunner)
+        .run(
+            Mockito.anyList(),
+            Mockito.eq(fakeGcloud.getRoot()),
+            Mockito.<Map<String, String>>any(),
+            Mockito.any(ConsoleListener.class));
   }
 
   private List<String> expectedCommand() {

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/components/SdkUpdaterTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/components/SdkUpdaterTest.java
@@ -21,8 +21,8 @@ import com.google.cloud.tools.managedcloudsdk.ProgressListener;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExecutionException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExitException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandRunner;
+import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +48,8 @@ public class SdkUpdaterTest {
   @Before
   public void setUpFakesAndMocks()
       throws InterruptedException, CommandExitException, CommandExecutionException {
-    fakeGcloudPath = Paths.get("/my/path/to/fake-gcloud");
+    Path root = FileSystems.getDefault().getRootDirectories().iterator().next();
+    fakeGcloudPath = root.resolve("my/path/to/fake-gcloud");
     Mockito.when(mockBundledPythonCopier.copyPython()).thenReturn(mockPythonEnv);
   }
 

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/components/SdkUpdaterTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/components/SdkUpdaterTest.java
@@ -43,19 +43,19 @@ public class SdkUpdaterTest {
   @Mock private BundledPythonCopier mockBundledPythonCopier;
   @Mock private Map<String, String> mockPythonEnv;
 
-  private Path fakeGcloud;
+  private Path fakeGcloudPath;
 
   @Before
   public void setUpFakesAndMocks()
       throws InterruptedException, CommandExitException, CommandExecutionException {
-    fakeGcloud = Paths.get("my/path/to/fake-gcloud");
+    fakeGcloudPath = Paths.get("/my/path/to/fake-gcloud");
     Mockito.when(mockBundledPythonCopier.copyPython()).thenReturn(mockPythonEnv);
   }
 
   @Test
   public void testUpdate_successRun()
       throws InterruptedException, CommandExitException, CommandExecutionException {
-    SdkUpdater testUpdater = new SdkUpdater(fakeGcloud, mockCommandRunner, null);
+    SdkUpdater testUpdater = new SdkUpdater(fakeGcloudPath, mockCommandRunner, null);
     testUpdater.update(mockProgressListener, mockConsoleListener);
     Mockito.verify(mockProgressListener).start(Mockito.anyString(), Mockito.eq(-1L));
     Mockito.verify(mockProgressListener).done();
@@ -70,7 +70,8 @@ public class SdkUpdaterTest {
   @Test
   public void testUpdate_withBundledPythonCopier()
       throws InterruptedException, CommandExitException, CommandExecutionException {
-    SdkUpdater testUpdater = new SdkUpdater(fakeGcloud, mockCommandRunner, mockBundledPythonCopier);
+    SdkUpdater testUpdater =
+        new SdkUpdater(fakeGcloudPath, mockCommandRunner, mockBundledPythonCopier);
     testUpdater.update(mockProgressListener, mockConsoleListener);
     Mockito.verify(mockProgressListener).start(Mockito.anyString(), Mockito.eq(-1L));
     Mockito.verify(mockProgressListener).done();
@@ -85,17 +86,17 @@ public class SdkUpdaterTest {
   @Test
   public void testInstallComponent_workingDirectorySet()
       throws InterruptedException, CommandExitException, CommandExecutionException {
-    SdkUpdater testUpdater = new SdkUpdater(fakeGcloud, mockCommandRunner, null);
+    SdkUpdater testUpdater = new SdkUpdater(fakeGcloudPath, mockCommandRunner, null);
     testUpdater.update(mockProgressListener, mockConsoleListener);
     Mockito.verify(mockCommandRunner)
         .run(
             Mockito.anyList(),
-            Mockito.eq(fakeGcloud.getRoot()),
+            Mockito.eq(fakeGcloudPath.getRoot()),
             Mockito.<Map<String, String>>any(),
             Mockito.any(ConsoleListener.class));
   }
 
   private List<String> expectedCommand() {
-    return Arrays.asList(fakeGcloud.toString(), "components", "update", "--quiet");
+    return Arrays.asList(fakeGcloudPath.toString(), "components", "update", "--quiet");
   }
 }


### PR DESCRIPTION
Fixes #651.

This is like executing the `gcloud` binary from the root directory.