### PR TITLE
Verify files to extract are under destination

### DIFF
--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Extractor.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Extractor.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.managedcloudsdk.ProgressListener;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.logging.Logger;
@@ -80,5 +81,11 @@ final class Extractor {
 
   private void cleanUp(final Path target) throws IOException {
     MoreFiles.deleteRecursively(target, RecursiveDeleteOption.ALLOW_INSECURE);
+  }
+
+  static boolean isTargetInsideDestination(Path destination, Path target) throws IOException {
+    String canonicalDestination = destination.toFile().getCanonicalPath();
+    String canonicalTarget = target.toFile().getCanonicalPath();
+    return canonicalTarget.startsWith(canonicalDestination + File.separator);
   }
 }

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/TarGzExtractorProvider.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/TarGzExtractorProvider.java
@@ -53,7 +53,11 @@ final class TarGzExtractorProvider implements ExtractorProvider {
     try (TarArchiveInputStream in = new TarArchiveInputStream(gzipIn)) {
       TarArchiveEntry entry;
       while ((entry = in.getNextTarEntry()) != null) {
-        final Path entryTarget = destination.resolve(entry.getName());
+        Path entryTarget = destination.resolve(entry.getName());
+
+        if (!Extractor.isTargetInsideDestination(destination, entryTarget)) {
+          throw new IOException("Blocked unzipping files outside destination: " + entry.getName());
+        }
 
         progressListener.update(1);
         logger.fine(entryTarget.toString());

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/ZipExtractorProvider.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/ZipExtractorProvider.java
@@ -62,6 +62,10 @@ final class ZipExtractorProvider implements ExtractorProvider {
         ZipArchiveEntry entry = zipEntries.nextElement();
         Path entryTarget = destination.resolve(entry.getName());
 
+        if (!Extractor.isTargetInsideDestination(destination, entryTarget)) {
+          throw new IOException("Blocked unzipping files outside destination: " + entry.getName());
+        }
+
         progressListener.update(1);
         logger.fine(entryTarget.toString());
 

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/ExtractorTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/ExtractorTest.java
@@ -104,9 +104,10 @@ public class ExtractorTest {
 
   @Test
   public void testIsTargetInsideDestination_targetInside() throws IOException {
-    Assert.assertTrue(Extractor.isTargetInsideDestination(
-        Paths.get("/tmp/../home//user/./destination"),
-        Paths.get("/./bin/../home/user///cache/./../destination/yes")));
+    Assert.assertTrue(
+        Extractor.isTargetInsideDestination(
+            Paths.get("/tmp/../home//user/./destination"),
+            Paths.get("/./bin/../home/user///cache/./../destination/yes")));
   }
 
   @Test
@@ -116,7 +117,7 @@ public class ExtractorTest {
 
   @Test
   public void testIsTargetInsideDestination_falseIfSame() throws IOException {
-    Assert.assertFalse(Extractor.isTargetInsideDestination(
-        Paths.get("/cool/path"), Paths.get("/cool/path")));
+    Assert.assertFalse(
+        Extractor.isTargetInsideDestination(Paths.get("/cool/path"), Paths.get("/cool/path")));
   }
 }

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/ExtractorTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/ExtractorTest.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.managedcloudsdk.ProgressListener;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -99,5 +100,23 @@ public class ExtractorTest {
     Assert.assertFalse(Files.exists(extractionDestination));
     Mockito.verify(mockExtractorProvider)
         .extract(extractionSource, extractionDestination, mockProgressListener);
+  }
+
+  @Test
+  public void testIsTargetInsideDestination_targetInside() throws IOException {
+    Assert.assertTrue(Extractor.isTargetInsideDestination(
+        Paths.get("/tmp/../home//user/./destination"),
+        Paths.get("/./bin/../home/user///cache/./../destination/yes")));
+  }
+
+  @Test
+  public void testIsTargetInsideDestination_targetOutside() throws IOException {
+    Assert.assertFalse(Extractor.isTargetInsideDestination(Paths.get("/tmp"), Paths.get("/")));
+  }
+
+  @Test
+  public void testIsTargetInsideDestination_falseIfSame() throws IOException {
+    Assert.assertFalse(Extractor.isTargetInsideDestination(
+        Paths.get("/cool/path"), Paths.get("/cool/path")));
   }
 }


### PR DESCRIPTION
We've been OK since we extract trusted archives (Cloud SDK zips) , but it's better to fix it correctly from the security point of view.

https://snyk.io/research/zip-slip-vulnerability#what-action-should-you-take

I've done actual installation on Linux and Windows.