### PR TITLE
Make LibrariesTest#assertReachable use HEAD to avoid downloading full artifact

### DIFF
--- a/src/test/java/com/google/cloud/tools/libraries/LibrariesTest.java
+++ b/src/test/java/com/google/cloud/tools/libraries/LibrariesTest.java
@@ -104,6 +104,7 @@ public class LibrariesTest {
 
   private static void assertReachable(String url) throws IOException {
     HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+    connection.setRequestMethod("HEAD");
     Assert.assertEquals("Could not reach " + url, 200, connection.getResponseCode());
   }
 


### PR DESCRIPTION
Saves almost 10 seconds on my machine.

Before:
```
Running com.google.cloud.tools.libraries.LibrariesTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 36.137 sec
```

After:
```
Running com.google.cloud.tools.libraries.LibrariesTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 26.436 sec
```