### PR TITLE
Enhance AppYaml

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineFlexibleStaging.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineFlexibleStaging.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.io.FileUtil;
 import com.google.cloud.tools.project.AppYaml;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.io.MoreFiles;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,9 +33,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
-import org.yaml.snakeyaml.error.YAMLException;
-import org.yaml.snakeyaml.parser.ParserException;
-import org.yaml.snakeyaml.scanner.ScannerException;
 
 /** Cloud SDK based implementation of {@link AppEngineFlexibleStaging}. */
 public class CloudSdkAppEngineFlexibleStaging implements AppEngineFlexibleStaging {
@@ -69,7 +67,7 @@ public class CloudSdkAppEngineFlexibleStaging implements AppEngineFlexibleStagin
       copyDockerContext(config, copyService, runtime);
       copyAppEngineContext(config, copyService);
       copyArtifact(config, copyService);
-    } catch (IOException | YAMLException ex) {
+    } catch (IOException ex) {
       throw new AppEngineException(ex);
     }
   }
@@ -78,18 +76,14 @@ public class CloudSdkAppEngineFlexibleStaging implements AppEngineFlexibleStagin
   @Nullable
   static String findRuntime(StageFlexibleConfiguration config)
       throws IOException, AppEngineException {
-    try {
-      // verify that app.yaml that contains runtime:java
-      File appEngineDirectory = config.getAppEngineDirectory();
-      if (appEngineDirectory == null) {
-        throw new AppEngineException("Invalid Staging Configuration: missing App Engine directory");
-      }
-      Path appYaml = appEngineDirectory.toPath().resolve(APP_YAML);
-      try (InputStream input = Files.newInputStream(appYaml)) {
-        return AppYaml.parse(input).getRuntime();
-      }
-    } catch (ScannerException | ParserException ex) {
-      throw new AppEngineException("Malformed 'app.yaml'.", ex);
+    // verify that app.yaml that contains runtime:java
+    File appEngineDirectory = config.getAppEngineDirectory();
+    if (appEngineDirectory == null) {
+      throw new AppEngineException("Invalid Staging Configuration: missing App Engine directory");
+    }
+    Path appYaml = appEngineDirectory.toPath().resolve(APP_YAML);
+    try (InputStream input = MoreFiles.asByteSource(appYaml).openBufferedStream()) {
+      return AppYaml.parse(input).getRuntime();
     }
   }
 

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineFlexibleStaging.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineFlexibleStaging.java
@@ -27,6 +27,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.logging.Logger;
@@ -84,7 +85,9 @@ public class CloudSdkAppEngineFlexibleStaging implements AppEngineFlexibleStagin
         throw new AppEngineException("Invalid Staging Configuration: missing App Engine directory");
       }
       Path appYaml = appEngineDirectory.toPath().resolve(APP_YAML);
-      return new AppYaml(appYaml).getRuntime();
+      try (InputStream input = Files.newInputStream(appYaml)) {
+        return AppYaml.parse(input).getRuntime();
+      }
     } catch (ScannerException | ParserException ex) {
       throw new AppEngineException("Malformed 'app.yaml'.", ex);
     }

--- a/src/main/java/com/google/cloud/tools/project/AppYaml.java
+++ b/src/main/java/com/google/cloud/tools/project/AppYaml.java
@@ -58,41 +58,56 @@ public class AppYaml {
     this.yamlMap = yamlMap == null ? Collections.emptyMap() : yamlMap;
   }
 
+  /**
+   * Return the content of the {@code environment} field, which defines this app's required App
+   * Engine environment.
+   */
   @Nullable
   public String getEnvironmentType() {
     return getString(ENVIRONMENT_TYPE_KEY);
   }
 
+  /** Return the content of the {@code runtime} field, which defines this app's expected runtime. */
   @Nullable
   public String getRuntime() {
     return getString(RUNTIME_KEY);
   }
 
+  /**
+   * Return the content of the {@code application} field, which identifies the App Engine API
+   * version used by this app.
+   */
   @Nullable
   public String getApiVersion() {
     return getString(API_VERSION_KEY);
   }
 
+  /** Return the content of the {@code application} field, which identifies the Project ID. */
   @Nullable
-  public String getApplication() {
+  public String getProjectId() {
     return getString(APPLICATION_KEY);
   }
 
+  /** Return the content of the {@code version} field, which identifies the Project version. */
   @Nullable
   public String getProjectVersion() {
     return getString(VERSION_KEY);
   }
 
-  @Nullable
-  public String getModuleId() {
-    return getString(MODULE_KEY);
-  }
-
+  /**
+   * Return the content of the {@code service} field or the now-deprecated {@code module} field,
+   * which identifies the Service ID.
+   */
   @Nullable
   public String getServiceId() {
-    return getString(SERVICE_KEY);
+    String serviceId = getString(SERVICE_KEY);
+    if (serviceId == null) {
+      serviceId = getString(MODULE_KEY);
+    }
+    return serviceId;
   }
 
+  /** Return the content of the {@code env_variables} field, which defines environment variables. */
   @Nullable
   public Map<String, ?> getEnvironmentVariables() {
     return getStringMap(ENVIRONMENT_VARIABLES_KEY);

--- a/src/main/java/com/google/cloud/tools/project/AppYaml.java
+++ b/src/main/java/com/google/cloud/tools/project/AppYaml.java
@@ -26,13 +26,14 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 /** Tools for reading {@code app.yaml}. */
 public class AppYaml {
 
+  private static final String ENVIRONMENT_TYPE_KEY = "env";
   private static final String RUNTIME_KEY = "runtime";
   private static final String API_VERSION_KEY = "api_version";
   private static final String APPLICATION_KEY = "application";
   private static final String VERSION_KEY = "version";
   private static final String SERVICE_KEY = "service";
   private static final String MODULE_KEY = "module";
-  private static final String ENVIRONMENT_KEY = "env_variables";
+  private static final String ENVIRONMENT_VARIABLES_KEY = "env_variables";
 
   private final Map<String, ?> yamlMap;
 
@@ -55,6 +56,11 @@ public class AppYaml {
 
   private AppYaml(Map<String, ?> yamlMap) {
     this.yamlMap = yamlMap == null ? Collections.emptyMap() : yamlMap;
+  }
+
+  @Nullable
+  public String getEnvironmentType() {
+    return getString(ENVIRONMENT_TYPE_KEY);
   }
 
   @Nullable
@@ -88,8 +94,8 @@ public class AppYaml {
   }
 
   @Nullable
-  public Map<String, ?> getEnvironment() {
-    return getStringMap(ENVIRONMENT_KEY);
+  public Map<String, ?> getEnvironmentVariables() {
+    return getStringMap(ENVIRONMENT_VARIABLES_KEY);
   }
 
   @Nullable

--- a/src/main/java/com/google/cloud/tools/project/AppYaml.java
+++ b/src/main/java/com/google/cloud/tools/project/AppYaml.java
@@ -92,11 +92,13 @@ public class AppYaml {
     return getStringMap(ENVIRONMENT_KEY);
   }
 
+  @Nullable
   private String getString(String key) {
     Object value = yamlMap.get(key);
     return value instanceof String ? (String) value : null;
   }
 
+  @Nullable
   @SuppressWarnings("unchecked")
   private Map<String, ?> getStringMap(String key) {
     Object value = yamlMap.get(key);

--- a/src/test/java/com/google/cloud/tools/appengine/AppEngineDescriptorTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/AppEngineDescriptorTest.java
@@ -124,7 +124,7 @@ public class AppEngineDescriptorTest {
   }
 
   @Test
-  public void testParse_null() throws AppEngineException, IOException, SAXException {
+  public void testParse_null() throws IOException, SAXException {
     try {
       AppEngineDescriptor.parse(null);
       Assert.fail("allowed null input");

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineFlexibleStagingTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineFlexibleStagingTest.java
@@ -41,7 +41,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/** Test the CloudSdkAppEngineFlexibleStaging functionality */
+/** Test the CloudSdkAppEngineFlexibleStaging functionality. */
 @RunWith(MockitoJUnitRunner.class)
 public class CloudSdkAppEngineFlexibleStagingTest {
 

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/GcloudRunnerTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/GcloudRunnerTest.java
@@ -67,7 +67,7 @@ public class GcloudRunnerTest {
   @Test
   public void testRun_builtFromFactory()
       throws CloudSdkOutOfDateException, CloudSdkNotFoundException, ProcessHandlerException,
-          CloudSdkVersionFileException, InvalidJavaSdkException, IOException {
+          CloudSdkVersionFileException, IOException {
     GcloudRunner gcloudRunner =
         new GcloudRunner.Factory(processBuilderFactory)
             .newRunner(

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResultTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/AppEngineDeployResultTest.java
@@ -139,7 +139,7 @@ public class AppEngineDeployResultTest {
   }
 
   @Test
-  public void testParse_errorWhenVersionIdMissing() throws JsonParseException {
+  public void testParse_errorWhenVersionIdMissing() {
     try {
       AppEngineDeployResult.parse(
           "{'versions': [ {'service': 'a-service', 'project': 'a-project'} ]}");
@@ -150,7 +150,7 @@ public class AppEngineDeployResultTest {
   }
 
   @Test
-  public void testParse_errorWhenVersionServiceMissing() throws JsonParseException {
+  public void testParse_errorWhenVersionServiceMissing() {
     try {
       AppEngineDeployResult.parse("{'versions': [ {'id': 'a-id', 'project': 'a-project'} ]}");
       fail();
@@ -160,7 +160,7 @@ public class AppEngineDeployResultTest {
   }
 
   @Test
-  public void testParse_errorWhenVersionProjectMissing() throws JsonParseException {
+  public void testParse_errorWhenVersionProjectMissing() {
     try {
       AppEngineDeployResult.parse("{'versions': [ {'id': 'a-id', 'service': 'a-service'} ]}");
       fail();

--- a/src/test/java/com/google/cloud/tools/project/AppYamlTest.java
+++ b/src/test/java/com/google/cloud/tools/project/AppYamlTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.project;
 
+import com.google.cloud.tools.appengine.api.AppEngineException;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -28,139 +29,139 @@ public class AppYamlTest {
 
   // https://github.com/GoogleCloudPlatform/appengine-plugins-core/issues/405
   @Test
-  public void testEmptyAppYaml() {
+  public void testEmptyAppYaml() throws AppEngineException {
     InputStream appYaml = asStream("");
     Assert.assertNull(AppYaml.parse(appYaml).getRuntime());
   }
 
   @Test
-  public void testIgnoresUnsupportedElements() {
+  public void testIgnoresUnsupportedElements() throws AppEngineException {
     InputStream appYaml = asStream("runtime: java\nhandlers:\n- url: /\n  script: foo.app\n");
     Assert.assertNotNull(AppYaml.parse(appYaml));
   }
 
   @Test
-  public void testGetEnvironmentType_success() {
+  public void testGetEnvironmentType_success() throws AppEngineException {
     InputStream appYaml = asStream("env: flex\nruntime: java\np2: v2");
     Assert.assertEquals("flex", AppYaml.parse(appYaml).getEnvironmentType());
   }
 
   @Test
-  public void testGetEnvironmentType_failureBecauseWrongType() {
+  public void testGetEnvironmentType_failureBecauseWrongType() throws AppEngineException {
     InputStream appYaml = asStream("env: [goose, moose]\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getEnvironmentType());
   }
 
   @Test
-  public void testGetEnvironmentType_failureBecauseNotPresent() {
+  public void testGetEnvironmentType_failureBecauseNotPresent() throws AppEngineException {
     InputStream appYaml = asStream("p1: v1\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getEnvironmentType());
   }
 
   @Test
-  public void testGetRuntime_success() {
+  public void testGetRuntime_success() throws AppEngineException {
     InputStream appYaml = asStream("runtime: java\np2: v2");
     Assert.assertEquals("java", AppYaml.parse(appYaml).getRuntime());
   }
 
   @Test
-  public void testGetRuntime_failureBecauseWrongType() {
+  public void testGetRuntime_failureBecauseWrongType() throws AppEngineException {
     InputStream appYaml = asStream("runtime: [goose, moose]\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getRuntime());
   }
 
   @Test
-  public void testGetRuntime_failureBecauseNotPresent() {
+  public void testGetRuntime_failureBecauseNotPresent() throws AppEngineException {
     InputStream appYaml = asStream("p1: v1\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getRuntime());
   }
 
   @Test
-  public void testGetApplication_success() {
+  public void testGetApplication_success() throws AppEngineException {
     InputStream appYaml = asStream("application: app\np2: v2");
     Assert.assertEquals("app", AppYaml.parse(appYaml).getProjectId());
   }
 
   @Test
-  public void testGetApplication_failureBecauseWrongType() {
+  public void testGetApplication_failureBecauseWrongType() throws AppEngineException {
     InputStream appYaml = asStream("application: [goose, moose]\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getProjectId());
   }
 
   @Test
-  public void testGetApplication_failureBecauseNotPresent() {
+  public void testGetApplication_failureBecauseNotPresent() throws AppEngineException {
     InputStream appYaml = asStream("p1: v1\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getProjectId());
   }
 
   @Test
-  public void testGetServiceId_success() {
+  public void testGetServiceId_success() throws AppEngineException {
     InputStream appYaml = asStream("service: service\np2: v2");
     Assert.assertEquals("service", AppYaml.parse(appYaml).getServiceId());
   }
 
   @Test
-  public void testGetServiceId_failureBecauseWrongType() {
+  public void testGetServiceId_failureBecauseWrongType() throws AppEngineException {
     InputStream appYaml = asStream("service: [goose, moose]\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getServiceId());
   }
 
   @Test
-  public void testGetServiceId_successWithModule() {
+  public void testGetServiceId_successWithModule() throws AppEngineException {
     InputStream appYaml = asStream("module: module\np2: v2");
     Assert.assertEquals("module", AppYaml.parse(appYaml).getServiceId());
   }
 
   @Test
-  public void testGetServiceId_failureWithModuleBecauseWrongType() {
+  public void testGetServiceId_failureWithModuleBecauseWrongType() throws AppEngineException {
     InputStream appYaml = asStream("module: [goose, moose]\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getServiceId());
   }
 
   @Test
-  public void testGetServiceId_failureBecauseNotPresent() {
+  public void testGetServiceId_failureBecauseNotPresent() throws AppEngineException {
     InputStream appYaml = asStream("p1: v1\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getServiceId());
   }
 
   @Test
-  public void testGetVersion_success() {
+  public void testGetVersion_success() throws AppEngineException {
     InputStream appYaml = asStream("version: ver\np2: v2");
     Assert.assertEquals("ver", AppYaml.parse(appYaml).getProjectVersion());
   }
 
   @Test
-  public void testGetVersion_failureBecauseWrongType() {
+  public void testGetVersion_failureBecauseWrongType() throws AppEngineException {
     InputStream appYaml = asStream("version: [goose, moose]\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getProjectVersion());
   }
 
   @Test
-  public void testGetVersion_failureBecauseNotPresent() {
+  public void testGetVersion_failureBecauseNotPresent() throws AppEngineException {
     InputStream appYaml = asStream("p1: v1\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getProjectVersion());
   }
 
   @Test
-  public void testGetApiVersion_success() {
+  public void testGetApiVersion_success() throws AppEngineException {
     InputStream appYaml = asStream("api_version: ver\np2: v2");
     Assert.assertEquals("ver", AppYaml.parse(appYaml).getApiVersion());
   }
 
   @Test
-  public void testGetApiVersion_failureBecauseWrongType() {
+  public void testGetApiVersion_failureBecauseWrongType() throws AppEngineException {
     InputStream appYaml = asStream("api_version: [goose, moose]\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getApiVersion());
   }
 
   @Test
-  public void testGetApiVersion_failureBecauseNotPresent() {
+  public void testGetApiVersion_failureBecauseNotPresent() throws AppEngineException {
     InputStream appYaml = asStream("p1: v1\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getApiVersion());
   }
 
   @Test
-  public void testGetEnvironmentVariables_success() {
+  public void testGetEnvironmentVariables_success() throws AppEngineException {
     InputStream appYaml = asStream("env_variables:\n  key1: value1\n  key2: 0\np2: v2");
     Map<String, ?> environment = AppYaml.parse(appYaml).getEnvironmentVariables();
     Assert.assertNotNull(environment);
@@ -170,13 +171,13 @@ public class AppYamlTest {
   }
 
   @Test
-  public void testGetEnvironmentVariables_failureBecauseWrongType() {
+  public void testGetEnvironmentVariables_failureBecauseWrongType() throws AppEngineException {
     InputStream appYaml = asStream("env_variables: [goose, moose]\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getEnvironmentVariables());
   }
 
   @Test
-  public void testGetEnvironmentVariables_failureBecauseNotPresent() {
+  public void testGetEnvironmentVariables_failureBecauseNotPresent() throws AppEngineException {
     InputStream appYaml = asStream("p1: v1\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getEnvironmentVariables());
   }

--- a/src/test/java/com/google/cloud/tools/project/AppYamlTest.java
+++ b/src/test/java/com/google/cloud/tools/project/AppYamlTest.java
@@ -111,6 +111,7 @@ public class AppYamlTest {
     Assert.assertEquals("module", AppYaml.parse(appYaml).getServiceId());
   }
 
+  @Test
   public void testGetServiceId_failureWithModuleBecauseWrongType() {
     InputStream appYaml = asStream("module: [goose, moose]\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getServiceId());

--- a/src/test/java/com/google/cloud/tools/project/AppYamlTest.java
+++ b/src/test/java/com/google/cloud/tools/project/AppYamlTest.java
@@ -40,6 +40,24 @@ public class AppYamlTest {
   }
 
   @Test
+  public void testGetEnvironmentType_success() {
+    InputStream appYaml = asStream("env: flex\nruntime: java\np2: v2");
+    Assert.assertEquals("flex", AppYaml.parse(appYaml).getEnvironmentType());
+  }
+
+  @Test
+  public void testGetEnvironmentType_failureBecauseWrongType() {
+    InputStream appYaml = asStream("env: [goose, moose]\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getEnvironmentType());
+  }
+
+  @Test
+  public void testGetEnvironmentType_failureBecauseNotPresent() {
+    InputStream appYaml = asStream("p1: v1\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getEnvironmentType());
+  }
+
+  @Test
   public void testGetRuntime_success() {
     InputStream appYaml = asStream("runtime: java\np2: v2");
     Assert.assertEquals("java", AppYaml.parse(appYaml).getRuntime());
@@ -148,9 +166,9 @@ public class AppYamlTest {
   }
 
   @Test
-  public void testGetEnvironment_success() {
+  public void testGetEnvironmentVariables_success() {
     InputStream appYaml = asStream("env_variables:\n  key1: value1\n  key2: 0\np2: v2");
-    Map<String, ?> environment = AppYaml.parse(appYaml).getEnvironment();
+    Map<String, ?> environment = AppYaml.parse(appYaml).getEnvironmentVariables();
     Assert.assertNotNull(environment);
     Assert.assertEquals(2, environment.size());
     Assert.assertEquals("value1", environment.get("key1"));
@@ -158,15 +176,15 @@ public class AppYamlTest {
   }
 
   @Test
-  public void testGetEnvironment_failureBecauseWrongType() {
+  public void testGetEnvironmentVariables_failureBecauseWrongType() {
     InputStream appYaml = asStream("env_variables: [goose, moose]\np2: v2");
-    Assert.assertNull(AppYaml.parse(appYaml).getEnvironment());
+    Assert.assertNull(AppYaml.parse(appYaml).getEnvironmentVariables());
   }
 
   @Test
-  public void testGetEnvironment_failureBecauseNotPresent() {
+  public void testGetEnvironmentVariables_failureBecauseNotPresent() {
     InputStream appYaml = asStream("p1: v1\np2: v2");
-    Assert.assertNull(AppYaml.parse(appYaml).getEnvironment());
+    Assert.assertNull(AppYaml.parse(appYaml).getEnvironmentVariables());
   }
 
   private InputStream asStream(String contents) {

--- a/src/test/java/com/google/cloud/tools/project/AppYamlTest.java
+++ b/src/test/java/com/google/cloud/tools/project/AppYamlTest.java
@@ -78,19 +78,19 @@ public class AppYamlTest {
   @Test
   public void testGetApplication_success() {
     InputStream appYaml = asStream("application: app\np2: v2");
-    Assert.assertEquals("app", AppYaml.parse(appYaml).getApplication());
+    Assert.assertEquals("app", AppYaml.parse(appYaml).getProjectId());
   }
 
   @Test
   public void testGetApplication_failureBecauseWrongType() {
     InputStream appYaml = asStream("application: [goose, moose]\np2: v2");
-    Assert.assertNull(AppYaml.parse(appYaml).getApplication());
+    Assert.assertNull(AppYaml.parse(appYaml).getProjectId());
   }
 
   @Test
   public void testGetApplication_failureBecauseNotPresent() {
     InputStream appYaml = asStream("p1: v1\np2: v2");
-    Assert.assertNull(AppYaml.parse(appYaml).getApplication());
+    Assert.assertNull(AppYaml.parse(appYaml).getProjectId());
   }
 
   @Test
@@ -106,27 +106,20 @@ public class AppYamlTest {
   }
 
   @Test
-  public void testGetServiceId_failureBecauseNotPresent() {
-    InputStream appYaml = asStream("p1: v1\np2: v2");
+  public void testGetServiceId_successWithModule() {
+    InputStream appYaml = asStream("module: module\np2: v2");
+    Assert.assertEquals("module", AppYaml.parse(appYaml).getServiceId());
+  }
+
+  public void testGetServiceId_failureWithModuleBecauseWrongType() {
+    InputStream appYaml = asStream("module: [goose, moose]\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getServiceId());
   }
 
   @Test
-  public void testGetModuleId_success() {
-    InputStream appYaml = asStream("module: module\np2: v2");
-    Assert.assertEquals("module", AppYaml.parse(appYaml).getModuleId());
-  }
-
-  @Test
-  public void testGetModuleId_failureBecauseWrongType() {
-    InputStream appYaml = asStream("module: [goose, moose]\np2: v2");
-    Assert.assertNull(AppYaml.parse(appYaml).getModuleId());
-  }
-
-  @Test
-  public void testGetModuleId_failureBecauseNotPresent() {
+  public void testGetServiceId_failureBecauseNotPresent() {
     InputStream appYaml = asStream("p1: v1\np2: v2");
-    Assert.assertNull(AppYaml.parse(appYaml).getModuleId());
+    Assert.assertNull(AppYaml.parse(appYaml).getServiceId());
   }
 
   @Test

--- a/src/test/java/com/google/cloud/tools/project/AppYamlTest.java
+++ b/src/test/java/com/google/cloud/tools/project/AppYamlTest.java
@@ -16,48 +16,160 @@
 
 package com.google.cloud.tools.project;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.util.Map;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 /** Tests for AppYaml parsing */
 public class AppYamlTest {
 
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Test
-  public void testGetRuntime_success() throws IOException {
-    Path appYaml = writeFile("runtime: java\np2: v2");
-    Assert.assertEquals("java", new AppYaml(appYaml).getRuntime());
-  }
-
-  @Test
-  public void testGetRuntime_failureBecauseWrongType() throws IOException {
-    Path appYaml = writeFile("runtime: [goose, moose]\np2: v2");
-    Assert.assertNull(new AppYaml(appYaml).getRuntime());
-  }
-
-  @Test
-  public void testGetRuntime_failureBecauseNotPresent() throws IOException {
-    Path appYaml = writeFile("p1: v1\np2: v2");
-    Assert.assertNull(new AppYaml(appYaml).getRuntime());
-  }
-
   // https://github.com/GoogleCloudPlatform/appengine-plugins-core/issues/405
   @Test
-  public void testGetRuntime_emptyAppYaml() throws IOException {
-    Path appYaml = writeFile("");
-    Assert.assertNull(new AppYaml(appYaml).getRuntime());
+  public void testEmptyAppYaml() {
+    InputStream appYaml = asStream("");
+    Assert.assertNull(AppYaml.parse(appYaml).getRuntime());
   }
 
-  private Path writeFile(String contents) throws IOException {
-    File destination = temporaryFolder.newFile();
-    return Files.write(destination.toPath(), contents.getBytes(StandardCharsets.UTF_8));
+  @Test
+  public void testIgnoresUnsupportedElements() {
+    InputStream appYaml = asStream("runtime: java\nhandlers:\n- url: /\n  script: foo.app\n");
+    Assert.assertNotNull(AppYaml.parse(appYaml));
+  }
+
+  @Test
+  public void testGetRuntime_success() {
+    InputStream appYaml = asStream("runtime: java\np2: v2");
+    Assert.assertEquals("java", AppYaml.parse(appYaml).getRuntime());
+  }
+
+  @Test
+  public void testGetRuntime_failureBecauseWrongType() {
+    InputStream appYaml = asStream("runtime: [goose, moose]\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getRuntime());
+  }
+
+  @Test
+  public void testGetRuntime_failureBecauseNotPresent() {
+    InputStream appYaml = asStream("p1: v1\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getRuntime());
+  }
+
+  @Test
+  public void testGetApplication_success() {
+    InputStream appYaml = asStream("application: app\np2: v2");
+    Assert.assertEquals("app", AppYaml.parse(appYaml).getApplication());
+  }
+
+  @Test
+  public void testGetApplication_failureBecauseWrongType() {
+    InputStream appYaml = asStream("application: [goose, moose]\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getApplication());
+  }
+
+  @Test
+  public void testGetApplication_failureBecauseNotPresent() {
+    InputStream appYaml = asStream("p1: v1\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getApplication());
+  }
+
+  @Test
+  public void testGetServiceId_success() {
+    InputStream appYaml = asStream("service: service\np2: v2");
+    Assert.assertEquals("service", AppYaml.parse(appYaml).getServiceId());
+  }
+
+  @Test
+  public void testGetServiceId_failureBecauseWrongType() {
+    InputStream appYaml = asStream("service: [goose, moose]\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getServiceId());
+  }
+
+  @Test
+  public void testGetServiceId_failureBecauseNotPresent() {
+    InputStream appYaml = asStream("p1: v1\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getServiceId());
+  }
+
+  @Test
+  public void testGetModuleId_success() {
+    InputStream appYaml = asStream("module: module\np2: v2");
+    Assert.assertEquals("module", AppYaml.parse(appYaml).getModuleId());
+  }
+
+  @Test
+  public void testGetModuleId_failureBecauseWrongType() {
+    InputStream appYaml = asStream("module: [goose, moose]\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getModuleId());
+  }
+
+  @Test
+  public void testGetModuleId_failureBecauseNotPresent() {
+    InputStream appYaml = asStream("p1: v1\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getModuleId());
+  }
+
+  @Test
+  public void testGetVersion_success() {
+    InputStream appYaml = asStream("version: ver\np2: v2");
+    Assert.assertEquals("ver", AppYaml.parse(appYaml).getProjectVersion());
+  }
+
+  @Test
+  public void testGetVersion_failureBecauseWrongType() {
+    InputStream appYaml = asStream("version: [goose, moose]\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getProjectVersion());
+  }
+
+  @Test
+  public void testGetVersion_failureBecauseNotPresent() {
+    InputStream appYaml = asStream("p1: v1\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getProjectVersion());
+  }
+
+  @Test
+  public void testGetApiVersion_success() {
+    InputStream appYaml = asStream("api_version: ver\np2: v2");
+    Assert.assertEquals("ver", AppYaml.parse(appYaml).getApiVersion());
+  }
+
+  @Test
+  public void testGetApiVersion_failureBecauseWrongType() {
+    InputStream appYaml = asStream("api_version: [goose, moose]\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getApiVersion());
+  }
+
+  @Test
+  public void testGetApiVersion_failureBecauseNotPresent() {
+    InputStream appYaml = asStream("p1: v1\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getApiVersion());
+  }
+
+  @Test
+  public void testGetEnvironment_success() {
+    InputStream appYaml = asStream("env_variables:\n  key1: value1\n  key2: 0\np2: v2");
+    Map<String, ?> environment = AppYaml.parse(appYaml).getEnvironment();
+    Assert.assertNotNull(environment);
+    Assert.assertEquals(2, environment.size());
+    Assert.assertEquals("value1", environment.get("key1"));
+    Assert.assertEquals(0, environment.get("key2"));
+  }
+
+  @Test
+  public void testGetEnvironment_failureBecauseWrongType() {
+    InputStream appYaml = asStream("env_variables: [goose, moose]\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getEnvironment());
+  }
+
+  @Test
+  public void testGetEnvironment_failureBecauseNotPresent() {
+    InputStream appYaml = asStream("p1: v1\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getEnvironment());
+  }
+
+  private InputStream asStream(String contents) {
+    return new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8));
   }
 }


### PR DESCRIPTION
The PR enhances the `AppYaml` class to provide roughly the same functionality as the `AppEngineDescriptor` class.  
  - I broke `AppYaml`'s constructor-based loader since it assumes the input comes from a file.  And active constructors aren't great.
    - the only consumers of `AppYaml` outside of `appengine-plugins-core` is CT4E
  - I wondered about moving `AppYaml` into `com.google.cloud.tools.appengine` to be alongside `AppEngineDescriptor`.  The `app.yaml` format doesn't seem to be used outside of App Engine, correct?

(Ideally `AppYaml` and `AppEngineDescriptor` would be a single POJO model object that could be loaded with either SnakeYAML or Jackson/Gson, but that involves quite a bit more work.  And surely there must be some code we can leverage somewhere?)