### PR TITLE
Run script at parent directory of extracted Cloud SDK

### DIFF
--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/InstallScriptProvider.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/InstallScriptProvider.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.managedcloudsdk.install;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -28,7 +29,7 @@ interface InstallScriptProvider {
    * the script itself and supporting CLI launch scripts. It does NOT provide configuration
    * parameters for the script.
    */
-  List<String> getScriptCommandLine();
+  List<String> getScriptCommandLine(Path installedSdkRoot);
 
   @Nullable
   Map<String, String> getScriptEnvironment();

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Installer.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Installer.java
@@ -56,7 +56,8 @@ final class Installer {
   /** Install a cloud sdk (only run this on LATEST). */
   public void install()
       throws CommandExitException, CommandExecutionException, InterruptedException {
-    List<String> command = new ArrayList<>(installScriptProvider.getScriptCommandLine());
+    List<String> command =
+        new ArrayList<>(installScriptProvider.getScriptCommandLine(installedSdkRoot));
     command.add("--path-update=false"); // don't update user's path
     command.add("--command-completion=false"); // don't add command completion
     command.add("--quiet"); // don't accept user input during install

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Installer.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Installer.java
@@ -60,7 +60,7 @@ final class Installer {
     command.add("--path-update=false"); // don't update user's path
     command.add("--command-completion=false"); // don't add command completion
     command.add("--quiet"); // don't accept user input during install
-    command.add("--usage-reporting=" + usageReporting); // usage reporing passthrough
+    command.add("--usage-reporting=" + usageReporting); // usage reporting passthrough
 
     Path workingDirectory = installedSdkRoot.getParent();
     Map<String, String> installerEnvironment = installScriptProvider.getScriptEnvironment();

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Installer.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Installer.java
@@ -62,10 +62,11 @@ final class Installer {
     command.add("--quiet"); // don't accept user input during install
     command.add("--usage-reporting=" + usageReporting); // usage reporing passthrough
 
+    Path workingDirectory = installedSdkRoot.getParent();
     Map<String, String> installerEnvironment = installScriptProvider.getScriptEnvironment();
 
     progressListener.start("Installing Cloud SDK", ProgressListener.UNKNOWN);
-    commandRunner.run(command, installedSdkRoot, installerEnvironment, consoleListener);
+    commandRunner.run(command, workingDirectory, installerEnvironment, consoleListener);
     progressListener.done();
   }
 

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/UnixInstallScriptProvider.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/UnixInstallScriptProvider.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.managedcloudsdk.install;
 
+import com.google.common.base.Preconditions;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,9 +30,11 @@ final class UnixInstallScriptProvider implements InstallScriptProvider {
   UnixInstallScriptProvider() {}
 
   @Override
-  public List<String> getScriptCommandLine() {
+  public List<String> getScriptCommandLine(Path installedSdkRoot) {
+    Preconditions.checkArgument(installedSdkRoot.isAbsolute(), "non-absolute SDK path");
+
     List<String> script = new ArrayList<>(1);
-    script.add("./google-cloud-sdk/install.sh");
+    script.add(installedSdkRoot.resolve("install.sh").toString());
     return script;
   }
 

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/WindowsInstallScriptProvider.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/WindowsInstallScriptProvider.java
@@ -32,7 +32,7 @@ final class WindowsInstallScriptProvider implements InstallScriptProvider {
     List<String> script = new ArrayList<>(3);
     script.add("cmd.exe");
     script.add("/c");
-    script.add("install.bat");
+    script.add("google-cloud-sdk/install.bat");
     return script;
   }
 

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/WindowsInstallScriptProvider.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/WindowsInstallScriptProvider.java
@@ -16,7 +16,9 @@
 
 package com.google.cloud.tools.managedcloudsdk.install;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,11 +30,13 @@ final class WindowsInstallScriptProvider implements InstallScriptProvider {
   WindowsInstallScriptProvider() {}
 
   @Override
-  public List<String> getScriptCommandLine() {
+  public List<String> getScriptCommandLine(Path installedSdkRoot) {
+    Preconditions.checkArgument(installedSdkRoot.isAbsolute(), "non-absolute SDK path");
+
     List<String> script = new ArrayList<>(3);
     script.add("cmd.exe");
     script.add("/c");
-    script.add("google-cloud-sdk\\install.bat");
+    script.add(installedSdkRoot.resolve("install.bat").toString());
     return script;
   }
 

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/WindowsInstallScriptProvider.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/WindowsInstallScriptProvider.java
@@ -32,7 +32,7 @@ final class WindowsInstallScriptProvider implements InstallScriptProvider {
     List<String> script = new ArrayList<>(3);
     script.add("cmd.exe");
     script.add("/c");
-    script.add("google-cloud-sdk/install.bat");
+    script.add("google-cloud-sdk\\install.bat");
     return script;
   }
 

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/InstallerTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/InstallerTest.java
@@ -55,7 +55,8 @@ public class InstallerTest {
   public void setUp() throws IOException {
     sdkParentDirectory = tmp.getRoot().toPath();
     fakeSdkRoot = tmp.newFolder().toPath();
-    Mockito.when(mockInstallScriptProvider.getScriptCommandLine()).thenReturn(fakeCommand);
+    Mockito.when(mockInstallScriptProvider.getScriptCommandLine(fakeSdkRoot))
+        .thenReturn(fakeCommand);
     Mockito.when(mockInstallScriptProvider.getScriptEnvironment()).thenReturn(fakeEnv);
   }
 

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/UnixInstallScriptProviderTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/UnixInstallScriptProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/UnixInstallScriptProviderTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/UnixInstallScriptProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google Inc.
+ * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,16 @@
 
 package com.google.cloud.tools.managedcloudsdk.install;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import javax.annotation.Nullable;
+import org.junit.Assert;
+import org.junit.Test;
 
-/** {@link InstallScriptProvider} for Mac and Linux. */
-final class UnixInstallScriptProvider implements InstallScriptProvider {
+public class UnixInstallScriptProviderTest {
 
-  /** Instantiated by {@link InstallerFactory}. */
-  UnixInstallScriptProvider() {}
-
-  @Override
-  public List<String> getScriptCommandLine() {
-    List<String> script = new ArrayList<>(1);
-    script.add("./google-cloud-sdk/install.sh");
-    return script;
-  }
-
-  // todo should probably return an empty map
-  @Override
-  @Nullable
-  public Map<String, String> getScriptEnvironment() {
-    return null;
+  @Test
+  public void testGetCommandLine() {
+    List<String> commandLine = new UnixInstallScriptProvider().getScriptCommandLine();
+    Assert.assertEquals(1, commandLine.size());
+    Assert.assertEquals("./google-cloud-sdk/install.sh", commandLine.get(0));
   }
 }

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/UnixInstallScriptProviderTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/UnixInstallScriptProviderTest.java
@@ -16,16 +16,35 @@
 
 package com.google.cloud.tools.managedcloudsdk.install;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class UnixInstallScriptProviderTest {
 
   @Test
-  public void testGetCommandLine() {
-    List<String> commandLine = new UnixInstallScriptProvider().getScriptCommandLine();
+  public void testGetScriptCommandLine_nonAbsoluteSdkRoot() {
+    try {
+      new UnixInstallScriptProvider().getScriptCommandLine(Paths.get("relative/path"));
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals("non-absolute SDK path", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetScriptCommandLine() {
+    Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
+
+    Path sdkRoot = Paths.get("/path/to/sdk");
+    List<String> commandLine = new UnixInstallScriptProvider().getScriptCommandLine(sdkRoot);
+
     Assert.assertEquals(1, commandLine.size());
-    Assert.assertEquals("./google-cloud-sdk/install.sh", commandLine.get(0));
+    Path scriptPath = Paths.get(commandLine.get(0));
+    Assert.assertTrue(scriptPath.isAbsolute());
+    Assert.assertEquals(Paths.get("/path/to/sdk/install.sh"), scriptPath);
   }
 }

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/WindowsInstallScriptProviderTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/WindowsInstallScriptProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/WindowsInstallScriptProviderTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/WindowsInstallScriptProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google Inc.
+ * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,18 @@
 
 package com.google.cloud.tools.managedcloudsdk.install;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import javax.annotation.Nullable;
+import org.junit.Assert;
+import org.junit.Test;
 
-/** {@link InstallScriptProvider} for Mac and Linux. */
-final class UnixInstallScriptProvider implements InstallScriptProvider {
+public class WindowsInstallScriptProviderTest {
 
-  /** Instantiated by {@link InstallerFactory}. */
-  UnixInstallScriptProvider() {}
-
-  @Override
-  public List<String> getScriptCommandLine() {
-    List<String> script = new ArrayList<>(1);
-    script.add("./google-cloud-sdk/install.sh");
-    return script;
-  }
-
-  // todo should probably return an empty map
-  @Override
-  @Nullable
-  public Map<String, String> getScriptEnvironment() {
-    return null;
+  @Test
+  public void testGetCommandLine() {
+    List<String> commandLine = new WindowsInstallScriptProvider().getScriptCommandLine();
+    Assert.assertEquals(3, commandLine.size());
+    Assert.assertEquals("cmd.exe", commandLine.get(0));
+    Assert.assertEquals("/c", commandLine.get(1));
+    Assert.assertEquals("google-cloud-sdk/install.bat", commandLine.get(2));
   }
 }

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/WindowsInstallScriptProviderTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/WindowsInstallScriptProviderTest.java
@@ -28,6 +28,6 @@ public class WindowsInstallScriptProviderTest {
     Assert.assertEquals(3, commandLine.size());
     Assert.assertEquals("cmd.exe", commandLine.get(0));
     Assert.assertEquals("/c", commandLine.get(1));
-    Assert.assertEquals("google-cloud-sdk/install.bat", commandLine.get(2));
+    Assert.assertEquals("google-cloud-sdk\\install.bat", commandLine.get(2));
   }
 }

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/WindowsInstallScriptProviderTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/WindowsInstallScriptProviderTest.java
@@ -16,18 +16,38 @@
 
 package com.google.cloud.tools.managedcloudsdk.install;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class WindowsInstallScriptProviderTest {
 
   @Test
-  public void testGetCommandLine() {
-    List<String> commandLine = new WindowsInstallScriptProvider().getScriptCommandLine();
+  public void testGetScriptCommandLine_nonAbsoluteSdkRoot() {
+    try {
+      new UnixInstallScriptProvider().getScriptCommandLine(Paths.get("relative/path"));
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals("non-absolute SDK path", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetScriptCommandLine() {
+    Assume.assumeTrue(System.getProperty("os.name").startsWith("Windows"));
+
+    Path sdkRoot = Paths.get("C:\\path\\to\\sdk");
+    List<String> commandLine = new WindowsInstallScriptProvider().getScriptCommandLine(sdkRoot);
+
     Assert.assertEquals(3, commandLine.size());
     Assert.assertEquals("cmd.exe", commandLine.get(0));
     Assert.assertEquals("/c", commandLine.get(1));
-    Assert.assertEquals("google-cloud-sdk\\install.bat", commandLine.get(2));
+
+    Path scriptPath = Paths.get(commandLine.get(2));
+    Assert.assertTrue(scriptPath.isAbsolute());
+    Assert.assertEquals(Paths.get("C:\\path\\to\\sdk\\install.bat"), scriptPath);
   }
 }


### PR DESCRIPTION
Fixes #666.

It'd be ideal to avoid hard-coding the Cloud SDK home directory name (`google-cloud-sdk`) in the install script command line providers by dynamically identifying the extracted directory name and appending it to the command line, but due to the loose-coupling between the extractor, the command line provider, and the installer, that's pretty difficult. Not sure if it is really worth trying that.