### PR TITLE
Update maven-surefire-plugin to allow excluding tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.21</version>
+        <version>2.21.0</version>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,13 @@
         </configuration>
       </plugin>
 
+      <!-- newer surefire for excluding tests -Dtest=!ManagedCloudSdkTest -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.21</version>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
Some tests take a while and it would be nice to be able to be able to exclude them for faster turnaround.  maven-surefire-plugin 2.19 or later supports a bang notation:
```
$ mvn -Dtest='!ManagedCloudSdkTest' verify
```

The two I've found useful:
  - `ManagedCloudSdkTest`: if no Cloud SDK is available (e.g., running tests from a scratch docker instance), this test downloads and installs the Cloud SDK
  - `LibrariesTest`: does a whole series of network calls