### PR TITLE
Accept "HEAD" as CloudSdkVersion

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
@@ -34,7 +34,7 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
 
   private final String version;
   private final int majorVersion;
-  private final int minorVerion;
+  private final int minorVersion;
   private final int patchVersion;
 
   @Nullable
@@ -52,22 +52,29 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
     Preconditions.checkNotNull(version, "Null version");
     Preconditions.checkArgument(!version.isEmpty(), "empty version");
 
-    Matcher matcher = SEMVER_PATTERN.matcher(version);
-    if (!matcher.matches()) {
-      throw new IllegalArgumentException(
-          String.format("Pattern \"%s\" is not a valid CloudSdkVersion.", version));
+    if ("HEAD".equals(version)) {
+      majorVersion = Integer.MAX_VALUE;
+      minorVersion = Integer.MAX_VALUE;
+      patchVersion = Integer.MAX_VALUE;
+      preRelease = null;
+      buildIdentifier = null;
+    } else {
+      Matcher matcher = SEMVER_PATTERN.matcher(version);
+      if (!matcher.matches()) {
+        throw new IllegalArgumentException(
+            String.format("Pattern \"%s\" is not a valid CloudSdkVersion.", version));
+      }
+
+      majorVersion = Integer.parseInt(matcher.group("major"));
+      minorVersion = Integer.parseInt(matcher.group("minor"));
+      patchVersion = Integer.parseInt(matcher.group("patch"));
+
+      preRelease =
+          matcher.group("prerelease") != null
+              ? new CloudSdkVersionPreRelease(matcher.group("prerelease"))
+              : null;
+      buildIdentifier = matcher.group("build");
     }
-
-    majorVersion = Integer.parseInt(matcher.group("major"));
-    minorVerion = Integer.parseInt(matcher.group("minor"));
-    patchVersion = Integer.parseInt(matcher.group("patch"));
-
-    preRelease =
-        matcher.group("prerelease") != null
-            ? new CloudSdkVersionPreRelease(matcher.group("prerelease"))
-            : null;
-    buildIdentifier = matcher.group("build");
-
     this.version = version;
   }
 
@@ -114,9 +121,9 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
     Preconditions.checkNotNull(other);
 
     // First, compare required fields
-    List<Integer> mine = ImmutableList.of(majorVersion, minorVerion, patchVersion);
+    List<Integer> mine = ImmutableList.of(majorVersion, minorVersion, patchVersion);
     List<Integer> others =
-        ImmutableList.of(other.getMajorVersion(), other.getMinorVerion(), other.getPatchVersion());
+        ImmutableList.of(other.getMajorVersion(), other.getMinorVersion(), other.getPatchVersion());
     for (int i = 0; i < mine.size(); i++) {
       int result = mine.get(i).compareTo(others.get(i));
       if (result != 0) {
@@ -142,7 +149,7 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(majorVersion, minorVerion, patchVersion, preRelease, buildIdentifier);
+    return Objects.hash(majorVersion, minorVersion, patchVersion, preRelease, buildIdentifier);
   }
 
   /**
@@ -164,7 +171,7 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
     CloudSdkVersion otherVersion = (CloudSdkVersion) obj;
 
     return Objects.equals(majorVersion, otherVersion.majorVersion)
-        && Objects.equals(minorVerion, otherVersion.minorVerion)
+        && Objects.equals(minorVersion, otherVersion.minorVersion)
         && Objects.equals(patchVersion, otherVersion.patchVersion)
         && Objects.equals(preRelease, otherVersion.preRelease)
         && Objects.equals(buildIdentifier, otherVersion.buildIdentifier);
@@ -174,8 +181,8 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
     return majorVersion;
   }
 
-  public int getMinorVerion() {
-    return minorVerion;
+  public int getMinorVersion() {
+    return minorVersion;
   }
 
   public int getPatchVersion() {

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
@@ -155,8 +155,7 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(
-        version, majorVersion, minorVersion, patchVersion, preRelease, buildIdentifier);
+    return Objects.hash(majorVersion, minorVersion, patchVersion, preRelease, buildIdentifier);
   }
 
   /**

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
@@ -52,12 +52,10 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
     Preconditions.checkNotNull(version, "Null version");
     Preconditions.checkArgument(!version.isEmpty(), "empty version");
 
-    if ("HEAD".equals(version.trim())) {
-      // For the choice of 99999,
-      // see https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/670
-      majorVersion = 99999;
-      minorVersion = 99999;
-      patchVersion = 99999;
+    if ("HEAD".equals(version)) {
+      majorVersion = -1;
+      minorVersion = -1;
+      patchVersion = -1;
       preRelease = null;
       buildIdentifier = null;
     } else {
@@ -122,10 +120,16 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
   public int compareTo(CloudSdkVersion other) {
     Preconditions.checkNotNull(other);
 
+    if ("HEAD".equals(version) && !"HEAD".equals(other.version)) {
+      return 1;
+    } else if (!"HEAD".equals(version) && "HEAD".equals(other.version)) {
+      return -1;
+    }
+
     // First, compare required fields
     List<Integer> mine = ImmutableList.of(majorVersion, minorVersion, patchVersion);
     List<Integer> others =
-        ImmutableList.of(other.getMajorVersion(), other.getMinorVersion(), other.getPatchVersion());
+        ImmutableList.of(other.majorVersion, other.minorVersion, other.patchVersion);
     for (int i = 0; i < mine.size(); i++) {
       int result = mine.get(i).compareTo(others.get(i));
       if (result != 0) {
@@ -151,7 +155,7 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(majorVersion, minorVersion, patchVersion, preRelease, buildIdentifier);
+    return Objects.hash(version, majorVersion, minorVersion, patchVersion, preRelease, buildIdentifier);
   }
 
   /**
@@ -177,18 +181,6 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
         && Objects.equals(patchVersion, otherVersion.patchVersion)
         && Objects.equals(preRelease, otherVersion.preRelease)
         && Objects.equals(buildIdentifier, otherVersion.buildIdentifier);
-  }
-
-  public int getMajorVersion() {
-    return majorVersion;
-  }
-
-  public int getMinorVersion() {
-    return minorVersion;
-  }
-
-  public int getPatchVersion() {
-    return patchVersion;
   }
 
   @Nullable

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.appengine.cloudsdk.serialization;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
@@ -33,9 +34,9 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
   private static final Pattern SEMVER_PATTERN = Pattern.compile(getSemVerRegex());
 
   private final String version;
-  private final int majorVersion;
-  private final int minorVersion;
-  private final int patchVersion;
+  @VisibleForTesting final int majorVersion;
+  @VisibleForTesting final int minorVersion;
+  @VisibleForTesting final int patchVersion;
 
   @Nullable
   private final CloudSdkVersionPreRelease preRelease; // optional pre-release component of version

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
@@ -155,7 +155,8 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(version, majorVersion, minorVersion, patchVersion, preRelease, buildIdentifier);
+    return Objects.hash(
+        version, majorVersion, minorVersion, patchVersion, preRelease, buildIdentifier);
   }
 
   /**

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
@@ -53,9 +53,11 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
     Preconditions.checkArgument(!version.isEmpty(), "empty version");
 
     if ("HEAD".equals(version.trim())) {
-      majorVersion = Integer.MAX_VALUE;
-      minorVersion = Integer.MAX_VALUE;
-      patchVersion = Integer.MAX_VALUE;
+      // For the choice of 99999,
+      // see https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/670
+      majorVersion = 99999;
+      minorVersion = 99999;
+      patchVersion = 99999;
       preRelease = null;
       buildIdentifier = null;
     } else {

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersion.java
@@ -52,7 +52,7 @@ public class CloudSdkVersion implements Comparable<CloudSdkVersion> {
     Preconditions.checkNotNull(version, "Null version");
     Preconditions.checkArgument(!version.isEmpty(), "empty version");
 
-    if ("HEAD".equals(version)) {
+    if ("HEAD".equals(version.trim())) {
       majorVersion = Integer.MAX_VALUE;
       minorVersion = Integer.MAX_VALUE;
       patchVersion = Integer.MAX_VALUE;

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.tools.appengine.cloudsdk.serialization.CloudSdkVersion;
 import com.google.common.io.Files;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -75,7 +76,7 @@ public class CloudSdkTest {
   @Test
   public void testMinimumCloudSdkVersion() {
     // 160.0 through 170.0 have serious bugs on Windows
-    assertTrue(CloudSdk.MINIMUM_VERSION.getMajorVersion() > 170);
+    assertTrue(CloudSdk.MINIMUM_VERSION.compareTo(new CloudSdkVersion("170.0.0")) > 0);
   }
 
   @Test

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
@@ -205,6 +205,87 @@ public class CloudSdkVersionTest {
   }
 
   @Test
+  public void testMajorVersionParsing() {
+    CloudSdkVersion major0 = new CloudSdkVersion("0.99.88");
+    CloudSdkVersion major1 = new CloudSdkVersion("1.77.66");
+    CloudSdkVersion major2 = new CloudSdkVersion("2.55.44");
+    CloudSdkVersion major3 = new CloudSdkVersion("3.33.22");
+    CloudSdkVersion major4 = new CloudSdkVersion("4.11.0");
+    CloudSdkVersion major5 = new CloudSdkVersion("5.0.11");
+    CloudSdkVersion major6 = new CloudSdkVersion("6.22.33");
+    CloudSdkVersion major7 = new CloudSdkVersion("7.44.55");
+    assertTrue(major0.compareTo(major1) < 0);
+    assertTrue(major1.compareTo(major2) < 0);
+    assertTrue(major2.compareTo(major3) < 0);
+    assertTrue(major3.compareTo(major4) < 0);
+    assertTrue(major4.compareTo(major5) < 0);
+    assertTrue(major5.compareTo(major6) < 0);
+    assertTrue(major6.compareTo(major7) < 0);
+
+    assertTrue(major7.compareTo(major6) > 0);
+    assertTrue(major6.compareTo(major5) > 0);
+    assertTrue(major5.compareTo(major4) > 0);
+    assertTrue(major4.compareTo(major3) > 0);
+    assertTrue(major3.compareTo(major2) > 0);
+    assertTrue(major2.compareTo(major1) > 0);
+    assertTrue(major1.compareTo(major0) > 0);
+  }
+
+  @Test
+  public void testMinorVersionParsing() {
+    CloudSdkVersion minor0 = new CloudSdkVersion("0.0.88");
+    CloudSdkVersion minor1 = new CloudSdkVersion("0.1.66");
+    CloudSdkVersion minor2 = new CloudSdkVersion("0.2.44");
+    CloudSdkVersion minor3 = new CloudSdkVersion("0.3.22");
+    CloudSdkVersion minor4 = new CloudSdkVersion("0.4.0");
+    CloudSdkVersion minor5 = new CloudSdkVersion("0.5.11");
+    CloudSdkVersion minor6 = new CloudSdkVersion("0.6.33");
+    CloudSdkVersion minor7 = new CloudSdkVersion("0.7.55");
+    assertTrue(minor0.compareTo(minor1) < 0);
+    assertTrue(minor1.compareTo(minor2) < 0);
+    assertTrue(minor2.compareTo(minor3) < 0);
+    assertTrue(minor3.compareTo(minor4) < 0);
+    assertTrue(minor4.compareTo(minor5) < 0);
+    assertTrue(minor5.compareTo(minor6) < 0);
+    assertTrue(minor6.compareTo(minor7) < 0);
+
+    assertTrue(minor7.compareTo(minor6) > 0);
+    assertTrue(minor6.compareTo(minor5) > 0);
+    assertTrue(minor5.compareTo(minor4) > 0);
+    assertTrue(minor4.compareTo(minor3) > 0);
+    assertTrue(minor3.compareTo(minor2) > 0);
+    assertTrue(minor2.compareTo(minor1) > 0);
+    assertTrue(minor1.compareTo(minor0) > 0);
+  }
+
+  @Test
+  public void testPatchVersionParsing() {
+    CloudSdkVersion patch0 = new CloudSdkVersion("0.99.0");
+    CloudSdkVersion patch1 = new CloudSdkVersion("0.99.1");
+    CloudSdkVersion patch2 = new CloudSdkVersion("0.99.2");
+    CloudSdkVersion patch3 = new CloudSdkVersion("0.99.3");
+    CloudSdkVersion patch4 = new CloudSdkVersion("0.99.4");
+    CloudSdkVersion patch5 = new CloudSdkVersion("0.99.5");
+    CloudSdkVersion patch6 = new CloudSdkVersion("0.99.6");
+    CloudSdkVersion patch7 = new CloudSdkVersion("0.99.7");
+    assertTrue(patch0.compareTo(patch1) < 0);
+    assertTrue(patch1.compareTo(patch2) < 0);
+    assertTrue(patch2.compareTo(patch3) < 0);
+    assertTrue(patch3.compareTo(patch4) < 0);
+    assertTrue(patch4.compareTo(patch5) < 0);
+    assertTrue(patch5.compareTo(patch6) < 0);
+    assertTrue(patch6.compareTo(patch7) < 0);
+
+    assertTrue(patch7.compareTo(patch6) > 0);
+    assertTrue(patch6.compareTo(patch5) > 0);
+    assertTrue(patch5.compareTo(patch4) > 0);
+    assertTrue(patch4.compareTo(patch3) > 0);
+    assertTrue(patch3.compareTo(patch2) > 0);
+    assertTrue(patch2.compareTo(patch1) > 0);
+    assertTrue(patch1.compareTo(patch0) > 0);
+  }
+
+  @Test
   public void testHashCode_heads() {
     assertEquals(new CloudSdkVersion("HEAD"), new CloudSdkVersion("HEAD"));
   }

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
@@ -52,9 +52,6 @@ public class CloudSdkVersionTest {
   public void testConstructor_head() {
     CloudSdkVersion version = new CloudSdkVersion("HEAD");
     assertEquals("HEAD", version.toString());
-    assertEquals(99999, version.getMajorVersion());
-    assertEquals(99999, version.getMinorVersion());
-    assertEquals(99999, version.getPatchVersion());
     assertNull(version.getPreRelease());
     assertNull(version.getBuildIdentifier());
   }
@@ -82,9 +79,6 @@ public class CloudSdkVersionTest {
   @Test
   public void testConstructor_requiredNumbersOnly() {
     CloudSdkVersion version = new CloudSdkVersion("0.1.0");
-    assertEquals(0, version.getMajorVersion());
-    assertEquals(1, version.getMinorVersion());
-    assertEquals(0, version.getPatchVersion());
     assertNull(version.getBuildIdentifier());
     assertNull(version.getPreRelease());
   }
@@ -92,9 +86,6 @@ public class CloudSdkVersionTest {
   @Test
   public void testConstructor_withPreRelease() {
     CloudSdkVersion version = new CloudSdkVersion("0.1.0-beta");
-    assertEquals(0, version.getMajorVersion());
-    assertEquals(1, version.getMinorVersion());
-    assertEquals(0, version.getPatchVersion());
     assertEquals(new CloudSdkVersionPreRelease("beta"), version.getPreRelease());
     assertNull(version.getBuildIdentifier());
   }
@@ -102,9 +93,6 @@ public class CloudSdkVersionTest {
   @Test
   public void testConstructor_withBuild() {
     CloudSdkVersion version = new CloudSdkVersion("0.1.0+12345v0");
-    assertEquals(0, version.getMajorVersion());
-    assertEquals(1, version.getMinorVersion());
-    assertEquals(0, version.getPatchVersion());
     assertEquals("12345v0", version.getBuildIdentifier());
     assertNull(version.getPreRelease());
   }
@@ -112,9 +100,6 @@ public class CloudSdkVersionTest {
   @Test
   public void testConstructor_withPreReleaseAndBuild() {
     CloudSdkVersion version = new CloudSdkVersion("0.1.0-beta.1.0+22xyz331");
-    assertEquals(0, version.getMajorVersion());
-    assertEquals(1, version.getMinorVersion());
-    assertEquals(0, version.getPatchVersion());
     assertEquals("22xyz331", version.getBuildIdentifier());
     assertEquals("beta.1.0", version.getPreRelease().toString());
   }
@@ -122,9 +107,6 @@ public class CloudSdkVersionTest {
   @Test
   public void testConstructor_buildBeforePreRelease() {
     CloudSdkVersion version = new CloudSdkVersion("0.1.0+v01234-beta.1");
-    assertEquals(0, version.getMajorVersion());
-    assertEquals(1, version.getMinorVersion());
-    assertEquals(0, version.getPatchVersion());
     // the build identifier should match greedily
     assertEquals("v01234-beta.1", version.getBuildIdentifier());
     assertNull(version.getPreRelease());
@@ -220,5 +202,15 @@ public class CloudSdkVersionTest {
   public void testCompareTo_headIsGreater() {
     assertTrue(new CloudSdkVersion("HEAD").compareTo(new CloudSdkVersion("0.1.0-alpha.1.0.1")) > 0);
     assertTrue(new CloudSdkVersion("0.1.0").compareTo(new CloudSdkVersion("HEAD")) < 0);
+  }
+
+  @Test
+  public void testHashCode_heads() {
+    assertEquals(new CloudSdkVersion("HEAD"), new CloudSdkVersion("HEAD"));
+  }
+
+  @Test
+  public void testHashCode_headAndNonHead() {
+    assertNotEquals(new CloudSdkVersion("HEAD"), new CloudSdkVersion("1.23.98"));
   }
 }

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
@@ -79,6 +79,9 @@ public class CloudSdkVersionTest {
   @Test
   public void testConstructor_requiredNumbersOnly() {
     CloudSdkVersion version = new CloudSdkVersion("0.1.0");
+    assertEquals(0, version.majorVersion);
+    assertEquals(1, version.minorVersion);
+    assertEquals(0, version.patchVersion);
     assertNull(version.getBuildIdentifier());
     assertNull(version.getPreRelease());
   }
@@ -86,6 +89,9 @@ public class CloudSdkVersionTest {
   @Test
   public void testConstructor_withPreRelease() {
     CloudSdkVersion version = new CloudSdkVersion("0.1.0-beta");
+    assertEquals(0, version.majorVersion);
+    assertEquals(1, version.minorVersion);
+    assertEquals(0, version.patchVersion);
     assertEquals(new CloudSdkVersionPreRelease("beta"), version.getPreRelease());
     assertNull(version.getBuildIdentifier());
   }
@@ -93,6 +99,9 @@ public class CloudSdkVersionTest {
   @Test
   public void testConstructor_withBuild() {
     CloudSdkVersion version = new CloudSdkVersion("0.1.0+12345v0");
+    assertEquals(0, version.majorVersion);
+    assertEquals(1, version.minorVersion);
+    assertEquals(0, version.patchVersion);
     assertEquals("12345v0", version.getBuildIdentifier());
     assertNull(version.getPreRelease());
   }
@@ -100,6 +109,9 @@ public class CloudSdkVersionTest {
   @Test
   public void testConstructor_withPreReleaseAndBuild() {
     CloudSdkVersion version = new CloudSdkVersion("0.1.0-beta.1.0+22xyz331");
+    assertEquals(0, version.majorVersion);
+    assertEquals(1, version.minorVersion);
+    assertEquals(0, version.patchVersion);
     assertEquals("22xyz331", version.getBuildIdentifier());
     assertEquals("beta.1.0", version.getPreRelease().toString());
   }
@@ -107,6 +119,9 @@ public class CloudSdkVersionTest {
   @Test
   public void testConstructor_buildBeforePreRelease() {
     CloudSdkVersion version = new CloudSdkVersion("0.1.0+v01234-beta.1");
+    assertEquals(0, version.majorVersion);
+    assertEquals(1, version.minorVersion);
+    assertEquals(0, version.patchVersion);
     // the build identifier should match greedily
     assertEquals("v01234-beta.1", version.getBuildIdentifier());
     assertNull(version.getPreRelease());

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
@@ -218,9 +218,7 @@ public class CloudSdkVersionTest {
 
   @Test
   public void testCompareTo_headIsGreater() {
-    assertTrue(
-        new CloudSdkVersion("HEAD").compareTo(new CloudSdkVersion("0.1.0-alpha.1.0.1")) > 0);
-    assertTrue(
-        new CloudSdkVersion("0.1.0").compareTo(new CloudSdkVersion("HEAD")) < 0);
+    assertTrue(new CloudSdkVersion("HEAD").compareTo(new CloudSdkVersion("0.1.0-alpha.1.0.1")) > 0);
+    assertTrue(new CloudSdkVersion("0.1.0").compareTo(new CloudSdkVersion("HEAD")) < 0);
   }
 }

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
@@ -52,9 +52,9 @@ public class CloudSdkVersionTest {
   public void testConstructor_head() {
     CloudSdkVersion version = new CloudSdkVersion("HEAD");
     assertEquals("HEAD", version.toString());
-    assertEquals(Integer.MAX_VALUE, version.getMajorVersion());
-    assertEquals(Integer.MAX_VALUE, version.getMinorVersion());
-    assertEquals(Integer.MAX_VALUE, version.getPatchVersion());
+    assertEquals(99999, version.getMajorVersion());
+    assertEquals(99999, version.getMinorVersion());
+    assertEquals(99999, version.getPatchVersion());
     assertNull(version.getPreRelease());
     assertNull(version.getBuildIdentifier());
   }

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkVersionTest.java
@@ -49,6 +49,17 @@ public class CloudSdkVersionTest {
   }
 
   @Test
+  public void testConstructor_head() {
+    CloudSdkVersion version = new CloudSdkVersion("HEAD");
+    assertEquals("HEAD", version.toString());
+    assertEquals(Integer.MAX_VALUE, version.getMajorVersion());
+    assertEquals(Integer.MAX_VALUE, version.getMinorVersion());
+    assertEquals(Integer.MAX_VALUE, version.getPatchVersion());
+    assertNull(version.getPreRelease());
+    assertNull(version.getBuildIdentifier());
+  }
+
+  @Test
   public void testConstructor_preReleaseBeforeNumber() {
     try {
       new CloudSdkVersion("v1.beta.3-1.0.0");
@@ -72,7 +83,7 @@ public class CloudSdkVersionTest {
   public void testConstructor_requiredNumbersOnly() {
     CloudSdkVersion version = new CloudSdkVersion("0.1.0");
     assertEquals(0, version.getMajorVersion());
-    assertEquals(1, version.getMinorVerion());
+    assertEquals(1, version.getMinorVersion());
     assertEquals(0, version.getPatchVersion());
     assertNull(version.getBuildIdentifier());
     assertNull(version.getPreRelease());
@@ -82,7 +93,7 @@ public class CloudSdkVersionTest {
   public void testConstructor_withPreRelease() {
     CloudSdkVersion version = new CloudSdkVersion("0.1.0-beta");
     assertEquals(0, version.getMajorVersion());
-    assertEquals(1, version.getMinorVerion());
+    assertEquals(1, version.getMinorVersion());
     assertEquals(0, version.getPatchVersion());
     assertEquals(new CloudSdkVersionPreRelease("beta"), version.getPreRelease());
     assertNull(version.getBuildIdentifier());
@@ -92,7 +103,7 @@ public class CloudSdkVersionTest {
   public void testConstructor_withBuild() {
     CloudSdkVersion version = new CloudSdkVersion("0.1.0+12345v0");
     assertEquals(0, version.getMajorVersion());
-    assertEquals(1, version.getMinorVerion());
+    assertEquals(1, version.getMinorVersion());
     assertEquals(0, version.getPatchVersion());
     assertEquals("12345v0", version.getBuildIdentifier());
     assertNull(version.getPreRelease());
@@ -102,7 +113,7 @@ public class CloudSdkVersionTest {
   public void testConstructor_withPreReleaseAndBuild() {
     CloudSdkVersion version = new CloudSdkVersion("0.1.0-beta.1.0+22xyz331");
     assertEquals(0, version.getMajorVersion());
-    assertEquals(1, version.getMinorVerion());
+    assertEquals(1, version.getMinorVersion());
     assertEquals(0, version.getPatchVersion());
     assertEquals("22xyz331", version.getBuildIdentifier());
     assertEquals("beta.1.0", version.getPreRelease().toString());
@@ -112,7 +123,7 @@ public class CloudSdkVersionTest {
   public void testConstructor_buildBeforePreRelease() {
     CloudSdkVersion version = new CloudSdkVersion("0.1.0+v01234-beta.1");
     assertEquals(0, version.getMajorVersion());
-    assertEquals(1, version.getMinorVerion());
+    assertEquals(1, version.getMinorVersion());
     assertEquals(0, version.getPatchVersion());
     // the build identifier should match greedily
     assertEquals("v01234-beta.1", version.getBuildIdentifier());
@@ -142,6 +153,17 @@ public class CloudSdkVersionTest {
   public void testEquals_buildNumbers() {
     assertEquals(new CloudSdkVersion("0.1.0-rc.1+123"), new CloudSdkVersion("0.1.0-rc.1+123"));
     assertNotEquals(new CloudSdkVersion("0.1.0-rc.1+123"), new CloudSdkVersion("0.1.0-rc.1+456"));
+  }
+
+  @Test
+  public void testEquals_heads() {
+    assertEquals(new CloudSdkVersion("HEAD"), new CloudSdkVersion("HEAD"));
+  }
+
+  @Test
+  public void testEquals_headAndNonHead() {
+    assertNotEquals(new CloudSdkVersion("0.1.0-rc.1+123"), new CloudSdkVersion("HEAD"));
+    assertNotEquals(new CloudSdkVersion("HEAD"), new CloudSdkVersion("1.0.0"));
   }
 
   @Test
@@ -187,5 +209,18 @@ public class CloudSdkVersionTest {
         new CloudSdkVersion("0.1.0-alpha").compareTo(new CloudSdkVersion("0.1.0-alpha.0")) < 0);
     assertTrue(
         new CloudSdkVersion("0.1.0-alpha.1.0.1").compareTo(new CloudSdkVersion("0.1.0-omega")) < 0);
+  }
+
+  @Test
+  public void testCompareTo_heads() {
+    assertEquals(0, new CloudSdkVersion("HEAD").compareTo(new CloudSdkVersion("HEAD")));
+  }
+
+  @Test
+  public void testCompareTo_headIsGreater() {
+    assertTrue(
+        new CloudSdkVersion("HEAD").compareTo(new CloudSdkVersion("0.1.0-alpha.1.0.1")) > 0);
+    assertTrue(
+        new CloudSdkVersion("0.1.0").compareTo(new CloudSdkVersion("HEAD")) < 0);
   }
 }


### PR DESCRIPTION
Fixes #561.

I should say this may not be an ideal way to deal with HEAD. I've wondered what `getMajorVersion()` etc should return for HEAD, and after some tries, I ended up assigning the max int limit to the individual elements. This has the following consequences.

- A HEAD is just another regular version, nothing special, only having high numbers that are unsurpassable.
- When comparing recency, HEAD is always later (greater) than any non-HEAD version, although in reality this will not hold in most cases.
- One HEAD version is semantically equal to another HEAD version, although this will not be true in reality in almost all cases.

And I also need to verify if the content of the `VERSION` file is exactly `HEAD` without any surplus space.