### PR TITLE
Update maven-bundle-plugin to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.5.0</version>
         <configuration>
           <!--
              Register as an Eclipse Buddy to allow discovery of CloudSdkResolver


### PR DESCRIPTION
Fixes missed package references as seen in https://github.com/GoogleCloudPlatform/google-cloud-eclipse/pull/3165