### PR TITLE
Passes --application flag to devappserver1 and 2.

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/api/devserver/DefaultRunConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/devserver/DefaultRunConfiguration.java
@@ -315,15 +315,15 @@ public class DefaultRunConfiguration implements RunConfiguration {
         additionalArguments != null ? ImmutableList.copyOf(additionalArguments) : null;
   }
 
-  /** Gets the App Engine project ID. */
+  /** Gets the GCP project ID. */
   @Override
   @Nullable
   public String getProjectId() {
     return projectId;
   }
 
-  /** Sets the App Engine project ID. */
-  public void setProjectId(String project) {
-    this.projectId = project;
+  /** Sets the GCP project ID. */
+  public void setProjectId(String projectId) {
+    this.projectId = projectId;
   }
 }

--- a/src/main/java/com/google/cloud/tools/appengine/api/devserver/DefaultRunConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/devserver/DefaultRunConfiguration.java
@@ -52,7 +52,7 @@ public class DefaultRunConfiguration implements RunConfiguration {
   @Nullable private File datastorePath;
   @Nullable private Map<String, String> environment;
   @Nullable private List<String> additionalArguments;
-  @Nullable private String project;
+  @Nullable private String projectId;
 
   @Override
   @Nullable
@@ -315,13 +315,16 @@ public class DefaultRunConfiguration implements RunConfiguration {
         additionalArguments != null ? ImmutableList.copyOf(additionalArguments) : null;
   }
 
+
+  /** Gets the App Engine project ID. */
   @Override
   @Nullable
-  public String getProject() {
-    return project;
+  public String getProjectId() {
+    return projectId;
   }
 
-  public void setProject(String project) {
-    this.project = project;
+  /** Sets the App Engine project ID. */
+  public void setProjectId(String project) {
+    this.projectId = project;
   }
 }

--- a/src/main/java/com/google/cloud/tools/appengine/api/devserver/DefaultRunConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/devserver/DefaultRunConfiguration.java
@@ -52,6 +52,7 @@ public class DefaultRunConfiguration implements RunConfiguration {
   @Nullable private File datastorePath;
   @Nullable private Map<String, String> environment;
   @Nullable private List<String> additionalArguments;
+  @Nullable private String project;
 
   @Override
   @Nullable
@@ -312,5 +313,15 @@ public class DefaultRunConfiguration implements RunConfiguration {
   public void setAdditionalArguments(List<String> additionalArguments) {
     this.additionalArguments =
         additionalArguments != null ? ImmutableList.copyOf(additionalArguments) : null;
+  }
+
+  @Override
+  @Nullable
+  public String getProject() {
+    return project;
+  }
+
+  public void setProject(String project) {
+    this.project = project;
   }
 }

--- a/src/main/java/com/google/cloud/tools/appengine/api/devserver/DefaultRunConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/devserver/DefaultRunConfiguration.java
@@ -315,7 +315,6 @@ public class DefaultRunConfiguration implements RunConfiguration {
         additionalArguments != null ? ImmutableList.copyOf(additionalArguments) : null;
   }
 
-
   /** Gets the App Engine project ID. */
   @Override
   @Nullable

--- a/src/main/java/com/google/cloud/tools/appengine/api/devserver/RunConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/devserver/RunConfiguration.java
@@ -112,6 +112,7 @@ public interface RunConfiguration {
   @Nullable
   List<String> getAdditionalArguments();
 
+  /** Gets the App Engine project ID. */
   @Nullable
-  String getProject();
+  String getProjectId();
 }

--- a/src/main/java/com/google/cloud/tools/appengine/api/devserver/RunConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/devserver/RunConfiguration.java
@@ -111,4 +111,7 @@ public interface RunConfiguration {
    */
   @Nullable
   List<String> getAdditionalArguments();
+
+  @Nullable
+  String getProject();
 }

--- a/src/main/java/com/google/cloud/tools/appengine/api/devserver/RunConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/devserver/RunConfiguration.java
@@ -112,7 +112,7 @@ public interface RunConfiguration {
   @Nullable
   List<String> getAdditionalArguments();
 
-  /** Gets the App Engine project ID. */
+  /** Gets the GCP project ID. */
   @Nullable
   String getProjectId();
 }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
@@ -82,7 +82,7 @@ public class CloudSdkAppEngineDevServer1 implements AppEngineDevServer {
     }
 
     arguments.addAll(DevAppServerArgs.get("default_gcs_bucket", config.getDefaultGcsBucketName()));
-    arguments.addAll(DevAppServerArgs.get("application", config.getProject()));
+    arguments.addAll(DevAppServerArgs.get("application", config.getProjectId()));
 
     // Arguments ignored by dev appserver 1
     checkAndWarnIgnored(config.getAdminHost(), "adminHost");

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1.java
@@ -82,6 +82,7 @@ public class CloudSdkAppEngineDevServer1 implements AppEngineDevServer {
     }
 
     arguments.addAll(DevAppServerArgs.get("default_gcs_bucket", config.getDefaultGcsBucketName()));
+    arguments.addAll(DevAppServerArgs.get("application", config.getProject()));
 
     // Arguments ignored by dev appserver 1
     checkAndWarnIgnored(config.getAdminHost(), "adminHost");

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer2.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer2.java
@@ -90,7 +90,7 @@ public class CloudSdkAppEngineDevServer2 implements AppEngineDevServer {
     arguments.addAll(DevAppServerArgs.get("clear_datastore", config.getClearDatastore()));
     arguments.addAll(DevAppServerArgs.get("datastore_path", config.getDatastorePath()));
     arguments.addAll(DevAppServerArgs.get("env_var", config.getEnvironment()));
-    arguments.addAll(DevAppServerArgs.get("application", config.getProject()));
+    arguments.addAll(DevAppServerArgs.get("application", config.getProjectId()));
 
     List<String> additionalArguments = config.getAdditionalArguments();
     if (additionalArguments != null) {

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer2.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer2.java
@@ -90,6 +90,7 @@ public class CloudSdkAppEngineDevServer2 implements AppEngineDevServer {
     arguments.addAll(DevAppServerArgs.get("clear_datastore", config.getClearDatastore()));
     arguments.addAll(DevAppServerArgs.get("datastore_path", config.getDatastorePath()));
     arguments.addAll(DevAppServerArgs.get("env_var", config.getEnvironment()));
+    arguments.addAll(DevAppServerArgs.get("application", config.getProject()));
 
     List<String> additionalArguments = config.getAdditionalArguments();
     if (additionalArguments != null) {

--- a/src/test/java/com/google/cloud/tools/appengine/api/devserver/DefaultRunConfigurationTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/api/devserver/DefaultRunConfigurationTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.appengine.api.devserver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class DefaultRunConfigurationTest {
+
+  @Test
+  public void testSetGetProjectId() {
+    DefaultRunConfiguration defaultRunConfiguration = new DefaultRunConfiguration();
+    assertNull(defaultRunConfiguration.getProjectId());
+    defaultRunConfiguration.setProjectId("my-project");
+    assertEquals("my-project", defaultRunConfiguration.getProjectId());
+  }
+}

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1Test.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1Test.java
@@ -135,7 +135,7 @@ public class CloudSdkAppEngineDevServer1Test {
     configuration.setDefaultGcsBucketName("buckets");
     configuration.setEnvironment(null);
     configuration.setAutomaticRestart(true);
-    configuration.setProject("my-project");
+    configuration.setProjectId("my-project");
 
     // these params are not used by devappserver1 and will log warnings
     configuration.setAdminHost("adminHost");

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1Test.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1Test.java
@@ -135,6 +135,7 @@ public class CloudSdkAppEngineDevServer1Test {
     configuration.setDefaultGcsBucketName("buckets");
     configuration.setEnvironment(null);
     configuration.setAutomaticRestart(true);
+    configuration.setProject("my-project");
 
     // these params are not used by devappserver1 and will log warnings
     configuration.setAdminHost("adminHost");
@@ -164,6 +165,7 @@ public class CloudSdkAppEngineDevServer1Test {
             "--address=host",
             "--port=8090",
             "--default_gcs_bucket=buckets",
+            "--application=my-project",
             "--allow_remote_shutdown",
             "--disable_update_check",
             "--ARG1",

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer2Test.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer2Test.java
@@ -95,7 +95,7 @@ public class CloudSdkAppEngineDevServer2Test {
     configuration.setClearDatastore(true);
     configuration.setDatastorePath(fakeDatastorePath.toFile());
     configuration.setEnvironment(null);
-    configuration.setProject("my-project");
+    configuration.setProjectId("my-project");
     configuration.setAdditionalArguments(Arrays.asList("--ARG1", "--ARG2"));
 
     SpyVerifier.newVerifier(configuration).verifyDeclaredSetters();

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer2Test.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer2Test.java
@@ -95,6 +95,7 @@ public class CloudSdkAppEngineDevServer2Test {
     configuration.setClearDatastore(true);
     configuration.setDatastorePath(fakeDatastorePath.toFile());
     configuration.setEnvironment(null);
+    configuration.setProject("my-project");
     configuration.setAdditionalArguments(Arrays.asList("--ARG1", "--ARG2"));
 
     SpyVerifier.newVerifier(configuration).verifyDeclaredSetters();
@@ -126,6 +127,7 @@ public class CloudSdkAppEngineDevServer2Test {
             "--default_gcs_bucket_name=buckets",
             "--clear_datastore=true",
             "--datastore_path=" + fakeDatastorePath,
+            "--application=my-project",
             "--ARG1",
             "--ARG2");
 


### PR DESCRIPTION
Fixes #567 

Next steps are to release a new version of `appengine-plugins-core` and use the new release in `app-maven-plugin` and `app-gradle-plugin`.