### PR TITLE
Read gcloud config (just project for now)

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/Gcloud.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/Gcloud.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.appengine.cloudsdk.process.ProcessHandler;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessHandlerException;
 import com.google.cloud.tools.appengine.cloudsdk.process.StringBuilderProcessOutputLineListener;
 import com.google.cloud.tools.appengine.cloudsdk.serialization.CloudSdkComponent;
+import com.google.cloud.tools.appengine.cloudsdk.serialization.CloudSdkConfig;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonSyntaxException;
@@ -100,6 +101,25 @@ public class Gcloud {
 
     String componentsJson = runCommand(command);
     return CloudSdkComponent.fromJsonList(componentsJson);
+  }
+
+  /**
+   * Returns a representation of gcloud config, it makes a synchronous call to gcloud config list to
+   * do so.
+   */
+  public CloudSdkConfig getConfig()
+      throws CloudSdkNotFoundException, CloudSdkOutOfDateException, CloudSdkVersionFileException,
+          IOException, ProcessHandlerException {
+    sdk.validateCloudSdk();
+
+    List<String> command =
+        new ImmutableList.Builder<String>()
+            .add("config", "list")
+            .addAll(GcloudArgs.get("format", "json"))
+            .build();
+
+    String configJson = runCommand(command);
+    return CloudSdkConfig.fromJson(configJson);
   }
 
   /**

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkConfig.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.appengine.cloudsdk.serialization;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.annotations.SerializedName;
+import javax.annotation.Nullable;
+
+/** Representation of gcloud state. Used for JSON serialization/deserialization. */
+public class CloudSdkConfig {
+
+  public static class Core {
+    @Nullable
+    @SerializedName("project")
+    public String project;
+  }
+
+  @Nullable
+  @SerializedName("core")
+  private Core core;
+
+  private static final Gson gson = new Gson();
+
+  private CloudSdkConfig() {}
+
+  public static CloudSdkConfig fromJson(String json) throws JsonSyntaxException {
+    return gson.fromJson(json, CloudSdkConfig.class);
+  }
+
+  /** Returns "project" from gcloud configuration and {@code null} if not configured. */
+  @Nullable
+  public String getProject() {
+    if (core == null) {
+      return null;
+    }
+    return core.project;
+  }
+}

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkConfigTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/serialization/CloudSdkConfigTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.appengine.cloudsdk.serialization;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CloudSdkConfigTest {
+
+  private static final String TEST_STRING =
+      "{\"core\":{\"account\":\"test@test.com\",\"project\":\"test-gcp-project\"}}";
+
+  @Test
+  public void testGetProject_withValue() {
+    Assert.assertEquals("test-gcp-project", CloudSdkConfig.fromJson(TEST_STRING).getProject());
+  }
+
+  @Test
+  public void testGetProject_unset() {
+    Assert.assertNull(CloudSdkConfig.fromJson("{}").getProject());
+  }
+}


### PR DESCRIPTION
This is required to allow plugins to read this information for injection into the devappserver or other areas that are indirectly linked to gcloud.