### PR TITLE
repo1.maven.org -> repo.maven.apache.org

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.2/apache-maven-3.5.2-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.2/apache-maven-3.5.2-bin.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ cache:
 install:
   # https://github.com/travis-ci/travis-ci/issues/8408
   - unset _JAVA_OPTIONS
-  # download Cloud SDK
+  # show external ip address
+  - dig +short myip.opendns.com @resolver1.opendns.com
   - curl --head --show-error https://repo1.maven.org/maven2/com/google/cloud/google-cloud-bigquery/1.41.0/
   - curl --head --show-error https://repo.maven.apache.org/maven2/com/google/cloud/google-cloud-bigquery/1.41.0/
+  # download Cloud SDK
   - wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-200.0.0-linux-x86_64.tar.gz
   - tar -xzf google-cloud-sdk-200.0.0-linux-x86_64.tar.gz -C /home/travis
   # update all Cloud SDK components

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ install:
   # https://github.com/travis-ci/travis-ci/issues/8408
   - unset _JAVA_OPTIONS
   # download Cloud SDK
+  - curl --head --show-error https://repo1.maven.org/maven2/com/google/cloud/google-cloud-bigquery/1.41.0/
+  - curl --head --show-error https://repo.maven.apache.org/maven2/com/google/cloud/google-cloud-bigquery/1.41.0/
   - wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-200.0.0-linux-x86_64.tar.gz
   - tar -xzf google-cloud-sdk-200.0.0-linux-x86_64.tar.gz -C /home/travis
   # update all Cloud SDK components

--- a/src/test/java/com/google/cloud/tools/libraries/LibrariesTest.java
+++ b/src/test/java/com/google/cloud/tools/libraries/LibrariesTest.java
@@ -165,7 +165,7 @@ public class LibrariesTest {
       JsonObject coordinates =
           ((JsonObject) api.getJsonArray("clients").get(0)).getJsonObject("mavenCoordinates");
       String repo =
-          "https://repo1.maven.org/maven2/"
+          "https://repo.maven.apache.org/maven2/"
               + coordinates.getString("groupId").replace('.', '/')
               + "/"
               + coordinates.getString("artifactId")


### PR DESCRIPTION
Try switching to repo.maven.apache.org to see if that will clear up occasional _403 Forbidden_ storms from accesses to Maven Central.