### PR TITLE
Use Path instead of File in deployment classes

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/api/deploy/DeployConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/deploy/DeployConfiguration.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.appengine.api.deploy;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -24,7 +24,7 @@ import javax.annotation.Nullable;
 public class DeployConfiguration {
 
   @Nullable private final String bucket;
-  private final List<File> deployables;
+  private final List<Path> deployables;
   @Nullable private final String imageUrl;
   @Nullable private final String projectId;
   @Nullable private final Boolean promote;
@@ -34,7 +34,7 @@ public class DeployConfiguration {
 
   private DeployConfiguration(
       @Nullable String bucket,
-      List<File> deployables,
+      List<Path> deployables,
       @Nullable String imageUrl,
       @Nullable String projectId,
       @Nullable Boolean promote,
@@ -58,7 +58,7 @@ public class DeployConfiguration {
   }
 
   /** List of deployable target directories or yaml files. */
-  public List<File> getDeployables() {
+  public List<Path> getDeployables() {
     return deployables;
   }
 
@@ -98,13 +98,13 @@ public class DeployConfiguration {
     return version;
   }
 
-  public static Builder builder(List<File> deployables) {
+  public static Builder builder(List<Path> deployables) {
     return new Builder(deployables);
   }
 
   public static final class Builder {
     @Nullable private String bucket;
-    private List<File> deployables;
+    private List<Path> deployables;
     @Nullable private String imageUrl;
     @Nullable private String projectId;
     @Nullable private Boolean promote;
@@ -112,7 +112,7 @@ public class DeployConfiguration {
     @Nullable private Boolean stopPreviousVersion;
     @Nullable private String version;
 
-    private Builder(List<File> deployables) {
+    private Builder(List<Path> deployables) {
       if (deployables == null || deployables.size() == 0) {
         throw new IllegalArgumentException("Null/empty deployables");
       }

--- a/src/main/java/com/google/cloud/tools/appengine/api/deploy/DeployProjectConfigurationConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/deploy/DeployProjectConfigurationConfiguration.java
@@ -16,25 +16,25 @@
 
 package com.google.cloud.tools.appengine.api.deploy;
 
-import java.io.File;
+import java.nio.file.Path;
 import javax.annotation.Nullable;
 
 /** Configuration for {@link AppEngineDeployment} project-level yaml deployments. */
 public class DeployProjectConfigurationConfiguration {
 
-  private final File appEngineDirectory;
+  private final Path appEngineDirectory;
   @Nullable private final String projectId;
   @Nullable private final String server;
 
   private DeployProjectConfigurationConfiguration(
-      File appEngineDirectory, @Nullable String projectId, @Nullable String server) {
+      Path appEngineDirectory, @Nullable String projectId, @Nullable String server) {
     this.appEngineDirectory = appEngineDirectory;
     this.projectId = projectId;
     this.server = server;
   }
 
   /** Directory with yaml configuration files. */
-  public File getAppEngineDirectory() {
+  public Path getAppEngineDirectory() {
     return appEngineDirectory;
   }
 
@@ -50,16 +50,16 @@ public class DeployProjectConfigurationConfiguration {
     return server;
   }
 
-  public static Builder builder(File appEngineDirectory) {
+  public static Builder builder(Path appEngineDirectory) {
     return new Builder(appEngineDirectory);
   }
 
   public static final class Builder {
-    private File appEngineDirectory;
+    private Path appEngineDirectory;
     @Nullable private String projectId;
     @Nullable private String server;
 
-    private Builder(File appEngineDirectory) {
+    private Builder(Path appEngineDirectory) {
       if (appEngineDirectory == null) {
         throw new NullPointerException("Null appEngineDirectory");
       }

--- a/src/main/java/com/google/cloud/tools/appengine/api/deploy/StageFlexibleConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/deploy/StageFlexibleConfiguration.java
@@ -16,22 +16,22 @@
 
 package com.google.cloud.tools.appengine.api.deploy;
 
-import java.io.File;
+import java.nio.file.Path;
 import javax.annotation.Nullable;
 
 /** Configuration for {@link AppEngineFlexibleStaging#stageFlexible(StageFlexibleConfiguration)}. */
 public class StageFlexibleConfiguration {
 
-  private final File appEngineDirectory;
-  @Nullable private final File dockerDirectory;
-  private final File artifact;
-  private final File stagingDirectory;
+  private final Path appEngineDirectory;
+  @Nullable private final Path dockerDirectory;
+  private final Path artifact;
+  private final Path stagingDirectory;
 
   private StageFlexibleConfiguration(
-      File appEngineDirectory,
-      @Nullable File dockerDirectory,
-      File artifact,
-      File stagingDirectory) {
+      Path appEngineDirectory,
+      @Nullable Path dockerDirectory,
+      Path artifact,
+      Path stagingDirectory) {
     this.appEngineDirectory = appEngineDirectory;
     this.dockerDirectory = dockerDirectory;
     this.artifact = artifact;
@@ -39,18 +39,18 @@ public class StageFlexibleConfiguration {
   }
 
   /** Directory containing {@code app.yaml}. */
-  public File getAppEngineDirectory() {
+  public Path getAppEngineDirectory() {
     return appEngineDirectory;
   }
 
   /** Directory containing {@code Dockerfile} and other resources used by it. */
   @Nullable
-  public File getDockerDirectory() {
+  public Path getDockerDirectory() {
     return dockerDirectory;
   }
 
   /** Artifact to deploy such as WAR or JAR. */
-  public File getArtifact() {
+  public Path getArtifact() {
     return artifact;
   }
 
@@ -58,21 +58,21 @@ public class StageFlexibleConfiguration {
    * Directory where {@code app.yaml}, files in docker directory, and the artifact to deploy will be
    * copied for deploying.
    */
-  public File getStagingDirectory() {
+  public Path getStagingDirectory() {
     return stagingDirectory;
   }
 
-  public static Builder builder(File appEngineDirectory, File artifact, File stagingDirectory) {
+  public static Builder builder(Path appEngineDirectory, Path artifact, Path stagingDirectory) {
     return new Builder(appEngineDirectory, artifact, stagingDirectory);
   }
 
   public static final class Builder {
-    private File appEngineDirectory;
-    @Nullable private File dockerDirectory;
-    private File artifact;
-    private File stagingDirectory;
+    private Path appEngineDirectory;
+    @Nullable private Path dockerDirectory;
+    private Path artifact;
+    private Path stagingDirectory;
 
-    Builder(File appEngineDirectory, File artifact, File stagingDirectory) {
+    Builder(Path appEngineDirectory, Path artifact, Path stagingDirectory) {
       if (appEngineDirectory == null) {
         throw new NullPointerException("Null appEngineDirectory");
       }
@@ -87,7 +87,7 @@ public class StageFlexibleConfiguration {
       this.stagingDirectory = stagingDirectory;
     }
 
-    public StageFlexibleConfiguration.Builder setDockerDirectory(@Nullable File dockerDirectory) {
+    public StageFlexibleConfiguration.Builder setDockerDirectory(@Nullable Path dockerDirectory) {
       this.dockerDirectory = dockerDirectory;
       return this;
     }

--- a/src/main/java/com/google/cloud/tools/appengine/api/deploy/StageStandardConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/deploy/StageStandardConfiguration.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.appengine.api.deploy;
 
-import java.io.File;
+import java.nio.file.Path;
 import javax.annotation.Nullable;
 
 /**
@@ -24,9 +24,9 @@ import javax.annotation.Nullable;
  * indicate that the configuration was not set, and thus assumes the tool default value.
  */
 public class StageStandardConfiguration {
-  private final File sourceDirectory;
-  private final File stagingDirectory;
-  @Nullable private final File dockerfile;
+  private final Path sourceDirectory;
+  private final Path stagingDirectory;
+  @Nullable private final Path dockerfile;
   @Nullable private final Boolean enableQuickstart;
   @Nullable private final Boolean disableUpdateCheck;
   @Nullable private final Boolean enableJarSplitting;
@@ -38,9 +38,9 @@ public class StageStandardConfiguration {
   @Nullable private final String runtime;
 
   private StageStandardConfiguration(
-      File sourceDirectory,
-      File stagingDirectory,
-      @Nullable File dockerfile,
+      Path sourceDirectory,
+      Path stagingDirectory,
+      @Nullable Path dockerfile,
       @Nullable Boolean enableQuickstart,
       @Nullable Boolean disableUpdateCheck,
       @Nullable Boolean enableJarSplitting,
@@ -65,18 +65,18 @@ public class StageStandardConfiguration {
   }
 
   /** The exploded war directory to stage from. */
-  public File getSourceDirectory() {
+  public Path getSourceDirectory() {
     return sourceDirectory;
   }
 
   /** The staging output directory. */
-  public File getStagingDirectory() {
+  public Path getStagingDirectory() {
     return stagingDirectory;
   }
 
   /** A dockerfile to copy into the staging directory. */
   @Nullable
-  public File getDockerfile() {
+  public Path getDockerfile() {
     return dockerfile;
   }
 
@@ -126,14 +126,14 @@ public class StageStandardConfiguration {
     return runtime;
   }
 
-  public static Builder builder(File sourceDirectory, File stagingDirectory) {
+  public static Builder builder(Path sourceDirectory, Path stagingDirectory) {
     return new Builder(sourceDirectory, stagingDirectory);
   }
 
   public static final class Builder {
-    private File sourceDirectory;
-    private File stagingDirectory;
-    @Nullable private File dockerfile;
+    private Path sourceDirectory;
+    private Path stagingDirectory;
+    @Nullable private Path dockerfile;
     @Nullable private Boolean enableQuickstart;
     @Nullable private Boolean disableUpdateCheck;
     @Nullable private Boolean enableJarSplitting;
@@ -144,7 +144,7 @@ public class StageStandardConfiguration {
     @Nullable private Boolean disableJarJsps;
     @Nullable private String runtime;
 
-    Builder(File sourceDirectory, File stagingDirectory) {
+    Builder(Path sourceDirectory, Path stagingDirectory) {
       if (sourceDirectory == null) {
         throw new NullPointerException("Null sourceDirectory");
       }
@@ -155,7 +155,7 @@ public class StageStandardConfiguration {
       this.stagingDirectory = stagingDirectory;
     }
 
-    public Builder setDockerfile(@Nullable File dockerfile) {
+    public Builder setDockerfile(@Nullable Path dockerfile) {
       this.dockerfile = dockerfile;
       return this;
     }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDeployment.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDeployment.java
@@ -24,7 +24,6 @@ import com.google.cloud.tools.appengine.cloudsdk.internal.args.GcloudArgs;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessHandlerException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -54,7 +53,7 @@ public class CloudSdkAppEngineDeployment implements AppEngineDeployment {
     Preconditions.checkNotNull(config);
     Preconditions.checkNotNull(config.getDeployables());
     Preconditions.checkArgument(config.getDeployables().size() > 0);
-    File workingDirectory = null;
+    Path workingDirectory = null;
 
     List<String> arguments = new ArrayList<>();
     arguments.add("app");
@@ -64,15 +63,14 @@ public class CloudSdkAppEngineDeployment implements AppEngineDeployment {
     // Instead, we have to run 'gcloud app deploy' from the staging directory to achieve this.
     // So, if we find that the only deployable in the list is a directory, we just run the command
     // from that directory without passing in any deployables to gcloud.
-    if (config.getDeployables().size() == 1 && config.getDeployables().get(0).isDirectory()) {
+    if (config.getDeployables().size() == 1 && Files.isDirectory(config.getDeployables().get(0))) {
       workingDirectory = config.getDeployables().get(0);
     } else {
-      for (File deployable : config.getDeployables()) {
-        if (!deployable.exists()) {
-          throw new IllegalArgumentException(
-              "Deployable " + deployable.toPath() + " does not exist.");
+      for (Path deployable : config.getDeployables()) {
+        if (!Files.exists(deployable)) {
+          throw new IllegalArgumentException("Deployable " + deployable + " does not exist.");
         }
-        arguments.add(deployable.toPath().toString());
+        arguments.add(deployable.toString());
       }
     }
 
@@ -131,7 +129,7 @@ public class CloudSdkAppEngineDeployment implements AppEngineDeployment {
     Preconditions.checkNotNull(configuration);
     Preconditions.checkNotNull(configuration.getAppEngineDirectory());
 
-    Path deployable = configuration.getAppEngineDirectory().toPath().resolve(filename);
+    Path deployable = configuration.getAppEngineDirectory().resolve(filename);
     Preconditions.checkArgument(
         Files.isRegularFile(deployable), deployable.toString() + " does not exist.");
 

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/GcloudRunner.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/GcloudRunner.java
@@ -25,6 +25,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +69,7 @@ class GcloudRunner {
    *
    * @param workingDirectory if null then the working directory of current Java process
    */
-  void run(List<String> arguments, @Nullable File workingDirectory)
+  void run(List<String> arguments, @Nullable Path workingDirectory)
       throws ProcessHandlerException, CloudSdkNotFoundException, CloudSdkOutOfDateException,
           CloudSdkVersionFileException, IOException {
 
@@ -90,7 +91,9 @@ class GcloudRunner {
 
     ProcessBuilder processBuilder = processBuilderFactory.newProcessBuilder();
     processBuilder.command(command);
-    processBuilder.directory(workingDirectory);
+    if (workingDirectory != null) {
+      processBuilder.directory(workingDirectory.toFile());
+    }
     processBuilder.environment().putAll(getGcloudCommandEnvironment());
     Process process = processBuilder.start();
     processHandler.handleProcess(process);

--- a/src/test/java/com/google/cloud/tools/appengine/api/deploy/StageFlexibleConfigurationTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/api/deploy/StageFlexibleConfigurationTest.java
@@ -18,14 +18,15 @@ package com.google.cloud.tools.appengine.api.deploy;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.Before;
 import org.junit.Test;
 
 public class StageFlexibleConfigurationTest {
 
   private StageFlexibleConfiguration configuration;
-  private File file = new File("");
+  private Path file = Paths.get("");
 
   @Before
   public void setUp() {

--- a/src/test/java/com/google/cloud/tools/appengine/api/deploy/StageStandardConfigurationTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/api/deploy/StageStandardConfigurationTest.java
@@ -20,15 +20,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import com.google.common.io.Files;
-import java.io.File;
+import java.nio.file.Path;
 import org.junit.Before;
 import org.junit.Test;
 
 public class StageStandardConfigurationTest {
 
   private StageStandardConfiguration configuration;
-  private File stagingDirectory = Files.createTempDir();
-  private File sourceDirectory = Files.createTempDir();
+  private Path stagingDirectory = Files.createTempDir().toPath();
+  private Path sourceDirectory = Files.createTempDir().toPath();
 
   @Before
   public void setUp() {

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDeploymentTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDeploymentTest.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -52,9 +53,9 @@ public class CloudSdkAppEngineDeploymentTest {
 
   @Rule public TemporaryFolder tmpDir = new TemporaryFolder();
 
-  private File appYaml1;
-  private File appYaml2;
-  private File stagingDirectory;
+  private Path appYaml1;
+  private Path appYaml2;
+  private Path stagingDirectory;
 
   private CloudSdkAppEngineDeployment deployment;
 
@@ -64,9 +65,9 @@ public class CloudSdkAppEngineDeploymentTest {
 
   @Before
   public void setUp() throws IOException {
-    appYaml1 = tmpDir.newFile("app1.yaml");
-    appYaml2 = tmpDir.newFile("app2.yaml");
-    stagingDirectory = tmpDir.newFolder("appengine-staging");
+    appYaml1 = tmpDir.newFile("app1.yaml").toPath();
+    appYaml2 = tmpDir.newFile("app2.yaml").toPath();
+    stagingDirectory = tmpDir.newFolder("appengine-staging").toPath();
     deployment = new CloudSdkAppEngineDeployment(gcloudRunner);
   }
 
@@ -236,7 +237,7 @@ public class CloudSdkAppEngineDeploymentTest {
   public void testDeployConfig() throws Exception {
     File testConfigYaml = tmpDir.newFile("testconfig.yaml");
     DeployProjectConfigurationConfiguration configuration =
-        DeployProjectConfigurationConfiguration.builder(tmpDir.getRoot())
+        DeployProjectConfigurationConfiguration.builder(tmpDir.getRoot().toPath())
             .setServer("appengine.google.com")
             .setProjectId("project")
             .build();
@@ -260,7 +261,7 @@ public class CloudSdkAppEngineDeploymentTest {
     File testConfigYaml = new File(tmpDir.getRoot(), "testconfig.yaml");
     assertFalse(testConfigYaml.exists());
     DeployProjectConfigurationConfiguration configuration =
-        DeployProjectConfigurationConfiguration.builder(tmpDir.getRoot()).build();
+        DeployProjectConfigurationConfiguration.builder(tmpDir.getRoot().toPath()).build();
     try {
       deployment.deployConfig("testconfig.yaml", configuration);
       fail();

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/GcloudRunnerTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/GcloudRunnerTest.java
@@ -45,7 +45,7 @@ public class GcloudRunnerTest {
   @Mock private CloudSdk sdk;
   private Path gcloudPath;
   private File credentialFile;
-  private File workingDirectory;
+  private Path workingDirectory;
   @Mock private ProcessHandler processHandler;
   @Mock private ProcessBuilderFactory processBuilderFactory;
   @Mock private ProcessBuilder processBuilder;
@@ -56,7 +56,7 @@ public class GcloudRunnerTest {
   public void setUp() throws IOException {
     credentialFile = testFolder.newFile("credential.file");
     gcloudPath = testFolder.getRoot().toPath().resolve("gcloud");
-    workingDirectory = testFolder.getRoot();
+    workingDirectory = testFolder.getRoot().toPath();
     when(sdk.getGCloudPath()).thenReturn(gcloudPath);
 
     when(processBuilderFactory.newProcessBuilder()).thenReturn(processBuilder);
@@ -83,7 +83,7 @@ public class GcloudRunnerTest {
 
     Mockito.verify(processBuilder).environment();
     Mockito.verify(processEnv).putAll(gcloudRunner.getGcloudCommandEnvironment());
-    Mockito.verify(processBuilder).directory(workingDirectory);
+    Mockito.verify(processBuilder).directory(workingDirectory.toFile());
 
     Mockito.verify(processHandler).handleProcess(process);
     Mockito.verify(processBuilder)


### PR DESCRIPTION
This is something we should've done a while ago. Just moving from File -> Path.
Part of #723 