### PR TITLE
Update getGaeRuntime to handle java11

### DIFF
--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1Test.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineDevServer1Test.java
@@ -62,6 +62,8 @@ public class CloudSdkAppEngineDevServer1Test {
 
   private CloudSdkAppEngineDevServer1 devServer;
 
+  private final Path java11Service =
+      Paths.get("src/test/resources/projects/EmptyStandard11Project");
   private final Path java8Service = Paths.get("src/test/resources/projects/EmptyStandard8Project");
   private final Path java7Service = Paths.get("src/test/resources/projects/EmptyStandard7Project");
 
@@ -202,7 +204,7 @@ public class CloudSdkAppEngineDevServer1Test {
 
     SpyVerifier.newVerifier(configuration)
         .verifyDeclaredGetters(
-            ImmutableMap.of("getServices", 7, "getJavaHomeDir", 2, "getJvmFlags", 2));
+            ImmutableMap.of("getServices", 8, "getJavaHomeDir", 2, "getJvmFlags", 2));
 
     // verify we are checking and ignoring these parameters
     Map<String, Object> paramWarnings = new HashMap<>();
@@ -574,12 +576,24 @@ public class CloudSdkAppEngineDevServer1Test {
   }
 
   @Test
-  public void testGetGaeRuntimeJava_isJava8() {
-    Assert.assertEquals("java8", CloudSdkAppEngineDevServer1.getGaeRuntimeJava(true));
+  public void testGetGaeRuntimeJava_isJava11() throws AppEngineException {
+    Assert.assertEquals(
+        "java11",
+        CloudSdkAppEngineDevServer1.getGaeRuntimeJava(
+            ImmutableList.of(java7Service, java8Service, java11Service)));
   }
 
   @Test
-  public void testGetGaeRuntimeJava_isNotJava8() {
-    Assert.assertEquals("java7", CloudSdkAppEngineDevServer1.getGaeRuntimeJava(false));
+  public void testGetGaeRuntimeJava_isJava8() throws AppEngineException {
+    Assert.assertEquals(
+        "java8",
+        CloudSdkAppEngineDevServer1.getGaeRuntimeJava(
+            ImmutableList.of(java7Service, java8Service)));
+  }
+
+  @Test
+  public void testGetGaeRuntimeJava_isNotJava8() throws AppEngineException {
+    Assert.assertEquals(
+        "java7", CloudSdkAppEngineDevServer1.getGaeRuntimeJava(ImmutableList.of(java7Service)));
   }
 }

--- a/src/test/resources/projects/EmptyStandard11Project/WEB-INF/appengine-web.xml
+++ b/src/test/resources/projects/EmptyStandard11Project/WEB-INF/appengine-web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2018 Google LLC. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+  <sessions-enabled>true</sessions-enabled>
+  <module>default</module>
+  <runtime>java11</runtime>
+</appengine-web-app>


### PR DESCRIPTION
Minor fix to injected dev appserver variables.

Looks like kickstart might be doing this a little differently.

fixes #745 