### PR TITLE
Rename LocalRun -> DevServers

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/operations/DevServers.java
+++ b/src/main/java/com/google/cloud/tools/appengine/operations/DevServers.java
@@ -20,11 +20,11 @@ import com.google.cloud.tools.appengine.operations.cloudsdk.process.ProcessHandl
 import com.google.common.annotations.VisibleForTesting;
 
 /** Create Dev App Servers. */
-public class LocalRun {
+public class DevServers {
   private final CloudSdk sdk;
   private final DevAppServerRunner.Factory devAppServerRunnerFactory;
 
-  private LocalRun(CloudSdk sdk, DevAppServerRunner.Factory devAppServerRunnerFactory) {
+  private DevServers(CloudSdk sdk, DevAppServerRunner.Factory devAppServerRunnerFactory) {
     this.devAppServerRunnerFactory = devAppServerRunnerFactory;
     this.sdk = sdk;
   }
@@ -56,9 +56,9 @@ public class LocalRun {
       this.runnerFactory = runnerFactory;
     }
 
-    /** Build an immutable LocalRun instance. */
-    public LocalRun build() {
-      return new LocalRun(sdk, runnerFactory);
+    /** Build an immutable DevServers instance. */
+    public DevServers build() {
+      return new DevServers(sdk, runnerFactory);
     }
   }
 }

--- a/src/test/java/com/google/cloud/tools/appengine/operations/DevServersRunnerTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/operations/DevServersRunnerTest.java
@@ -44,7 +44,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class LocalRunRunnerTest {
+public class DevServersRunnerTest {
 
   private final boolean IS_WINDOWS = System.getProperty("os.name").contains("Windows");
 

--- a/src/test/java/com/google/cloud/tools/appengine/operations/DevServersTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/operations/DevServersTest.java
@@ -24,7 +24,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class LocalRunTest {
+public class DevServersTest {
 
   @Mock private DevAppServerRunner.Factory devAppServerRunnerFactory;
   @Mock private CloudSdk sdk;
@@ -32,7 +32,7 @@ public class LocalRunTest {
 
   @Test
   public void testGetRunner_parametersPassedToFactory() {
-    new LocalRun.Builder(sdk, devAppServerRunnerFactory).build().getRunner(processHandler);
+    new DevServers.Builder(sdk, devAppServerRunnerFactory).build().getRunner(processHandler);
     Mockito.verify(devAppServerRunnerFactory).newRunner(sdk, processHandler);
   }
 }


### PR DESCRIPTION
LocalRun wasn't a good choice.

DevServers matches much better.