### PR TITLE
Set up Travis build matrix to include OpenJDK 11 build / upgrade plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 sudo: false
 language: java
-jdk:
-  # no openjdk8 yet on travis without special configuration
-  - oraclejdk8
+matrix:
+  include:
+    - name: Oracle JDK 8
+      # no openjdk8 yet on travis without special configuration
+      jdk: oraclejdk8
+    - name: OpenJDK 11
+      jdk: openjdk11
 cache:
   directories:
    - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -131,8 +131,8 @@
         <version>3.8.0</version>
         <configuration>
           <!-- Use <release> instead when migrating to JDK 11. -->
-          <source>8</source>
-          <target>8</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
           <annotationProcessorPaths>

--- a/pom.xml
+++ b/pom.xml
@@ -128,44 +128,30 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.8.0</version>
         <configuration>
-          <compilerId>javac-with-errorprone</compilerId>
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-          <!-- maven-compiler-plugin defaults to targeting Java 5, but our javac
-          only supports >=6 -->
-          <source>1.8</source>
-          <target>1.8</target>
+          <!-- Use <release> instead when migrating to JDK 11. -->
+          <source>8</source>
+          <target>8</target>
+          <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
           <annotationProcessorPaths>
             <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>2.3.2</version>
+            </path>
+            <path>
               <groupId>com.uber.nullaway</groupId>
               <artifactId>nullaway</artifactId>
-              <version>0.4.4</version>
+              <version>0.6.4</version>
             </path>
           </annotationProcessorPaths>
           <compilerArgs>
-            <arg>-Xep:NullAway:ERROR</arg>
-            <arg>-XepOpt:NullAway:AnnotatedPackages=com.google.cloud.tools</arg>
-            <arg>-XepOpt:NullAway:ExcludedFieldAnnotations=org.mockito.Mock,org.junit.runners.Parameterized</arg>
-            <arg>-XepOpt:NullAway:ExcludedClasses=com.google.cloud.tools.appengine.operations.DevServerV1Test,com.google.cloud.tools.appengine.operations.cloudsdk.serialization.AppEngineDeployResult,com.google.cloud.tools.io.FilePermissionsTest,com.google.cloud.tools.appengine.operations.DevServerV2Test,com.google.cloud.tools.managedcloudsdk.install.InstallerFactoryTest,com.google.cloud.tools.appengine.AppEngineDescriptorTest,com.google.cloud.tools.appengine.operations.cloudsdk.serialization.CloudSdkVersionTest,com.google.cloud.tools.appengine.operations.GenRepoInfoFileTest,com.google.cloud.tools.appengine.operations.DeploymentTest,com.google.cloud.tools.appengine.operations.AuthTest</arg>
-            <arg>-XepOpt:NullAway:KnownInitializers=com.google.gson.Gson.fromJson</arg>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne -Xep:NullAway:ERROR -XepOpt:NullAway:AnnotatedPackages=com.google.cloud.tools -XepOpt:NullAway:KnownInitializers=com.google.gson.Gson.fromJson -XepOpt:NullAway:ExcludedFieldAnnotations=org.mockito.Mock,org.junit.runners.Parameterized -XepOpt:NullAway:ExcludedClasses=com.google.cloud.tools.appengine.operations.DevServerV1Test,com.google.cloud.tools.appengine.operations.cloudsdk.serialization.AppEngineDeployResult,com.google.cloud.tools.io.FilePermissionsTest,com.google.cloud.tools.appengine.operations.DevServerV2Test,com.google.cloud.tools.managedcloudsdk.install.InstallerFactoryTest,com.google.cloud.tools.appengine.AppEngineDescriptorTest,com.google.cloud.tools.appengine.operations.cloudsdk.serialization.CloudSdkVersionTest,com.google.cloud.tools.appengine.operations.GenRepoInfoFileTest,com.google.cloud.tools.appengine.operations.DeploymentTest,com.google.cloud.tools.appengine.operations.AuthTest</arg>
           </compilerArgs>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>2.8.3</version>
-          </dependency>
-          <!-- override plexus-compiler-javac-errorprone's dependency on
-          Error Prone with the latest version -->
-          <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <version>2.3.1</version>
-          </dependency>
-        </dependencies>
       </plugin>
 
       <plugin>
@@ -184,7 +170,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.21.0</version>
+        <version>2.22.1</version>
       </plugin>
 
       <plugin>
@@ -288,7 +274,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.1</version>
+        <version>0.8.2</version>
         <executions>
           <execution>
             <id>initialize</id>
@@ -347,9 +333,6 @@
                       <goal>compile</goal>
                       <goal>testCompile</goal>
                     </goals>
-                    <parameters>
-                      <compilerId>javac-with-errorprone</compilerId>
-                    </parameters>
                   </pluginExecutionFilter>
                   <action>
                     <configurator>
@@ -432,6 +415,34 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!--
+      Using github.com/google/error-prone-javac is required when running on
+      JDK 8. Remove when migrating to JDK 11.
+    -->
+    <profile>
+      <id>jdk8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <properties>
+        <javac.version>9+181-r4173-1</javac.version>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <fork>true</fork>
+              <compilerArgs combine.children="append">
+                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
+              </compilerArgs>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Trying out our build tools on Java 11. (Lot of changes based on https://github.com/GoogleContainerTools/jib/pull/1386)