### PR TITLE
update Checkstyle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.8</version>
+            <version>8.18</version>
           </dependency>
         </dependencies>
         <configuration>


### PR DESCRIPTION
@loosebazooka 

CVE-2019-9658
More information
moderate severity
Vulnerable versions: < 8.18
Patched version: 8.18

Checkstyle prior to 8.18 loads external DTDs by default, which can potentially lead to denial of service attacks or the leaking of confidential information.
