### PR TITLE
Create parent if it doesn't exists when copying files

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStaging.java
+++ b/src/main/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStaging.java
@@ -259,6 +259,9 @@ public class AppYamlProjectStaging {
     }
 
     void copyFileAndReplace(Path src, Path dest) throws IOException {
+      if (!Files.exists(dest.getParent())) {
+        Files.createDirectories(dest.getParent());
+      }
       Files.copy(src, dest, REPLACE_EXISTING);
     }
   }

--- a/src/test/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStagingTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStagingTest.java
@@ -473,6 +473,8 @@ public class AppYamlProjectStagingTest {
     Assert.assertTrue(Files.exists(destFile));
 
     copier.copyFileAndReplace(srcFile, destFile);
+
+    Assert.assertArrayEquals(Files.readAllBytes(srcFile), Files.readAllBytes(destFile));
   }
 
   @Test
@@ -493,5 +495,7 @@ public class AppYamlProjectStagingTest {
     Assert.assertFalse(Files.exists(destFile));
 
     copier.copyFileAndReplace(srcFile, destFile);
+
+    Assert.assertArrayEquals(Files.readAllBytes(srcFile), Files.readAllBytes(destFile));
   }
 }

--- a/src/test/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStagingTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStagingTest.java
@@ -452,4 +452,46 @@ public class AppYamlProjectStagingTest {
             + " referenced in MANIFEST.MF",
         logs.get(0).getMessage());
   }
+
+  @Test
+  public void testCopyService_copiesToExistingFile() throws IOException {
+    AppYamlProjectStaging.CopyService copier = new AppYamlProjectStaging.CopyService();
+    Path root = temporaryFolder.getRoot().toPath();
+
+    Path srcDir = root.resolve("srcDir");
+    Files.createDirectory(srcDir);
+    Path srcFile = srcDir.resolve("srcFile");
+    Files.createFile(srcFile);
+    Files.write(srcFile, "some content".getBytes(StandardCharsets.UTF_8));
+
+    Path destDir = root.resolve("destDir");
+    Files.createDirectory(destDir);
+    Path destFile = destDir.resolve("destFile");
+    Files.createFile(destFile);
+
+    Assert.assertTrue(Files.exists(destDir));
+    Assert.assertTrue(Files.exists(destFile));
+
+    copier.copyFileAndReplace(srcFile, destFile);
+  }
+
+  @Test
+  public void testCopyService_createsParentsWhenNecessary() throws IOException {
+    AppYamlProjectStaging.CopyService copier = new AppYamlProjectStaging.CopyService();
+    Path root = temporaryFolder.getRoot().toPath();
+
+    Path srcDir = root.resolve("srcDir");
+    Files.createDirectory(srcDir);
+    Path srcFile = srcDir.resolve("srcFile");
+    Files.createFile(srcFile);
+    Files.write(srcFile, "some content".getBytes(StandardCharsets.UTF_8));
+
+    Path destDir = root.resolve("destDir");
+    Path destFile = destDir.resolve("destFile");
+
+    Assert.assertFalse(Files.exists(destDir));
+    Assert.assertFalse(Files.exists(destFile));
+
+    copier.copyFileAndReplace(srcFile, destFile);
+  }
 }


### PR DESCRIPTION
Probably should've had a test for this :\