### PR TITLE
Add minikube and skaffold to list of gcloud components

### DIFF
--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -2,7 +2,8 @@
 
 REM Java 9 does not work with our builds right now, force java 8
 set JAVA_HOME=c:\program files\java\jdk1.8.0_152
-set PATH=%JAVA_HOME%\bin;%PATH%
+set CLOUDSDK_PYTHON=c:\python27\python.exe
+set PATH=%CLOUDSDK_PYTHON%;%JAVA_HOME%\bin;%PATH%
 
 cd github/appengine-plugins-core
 

--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -2,8 +2,7 @@
 
 REM Java 9 does not work with our builds right now, force java 8
 set JAVA_HOME=c:\program files\java\jdk1.8.0_152
-set CLOUDSDK_PYTHON=c:\python27\python.exe
-set PATH=%CLOUDSDK_PYTHON%;%JAVA_HOME%\bin;%PATH%
+set PATH=%JAVA_HOME%\bin;%PATH%
 
 cd github/appengine-plugins-core
 

--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -3,7 +3,6 @@
 REM Java 9 does not work with our builds right now, force java 8
 set JAVA_HOME=c:\program files\java\jdk1.8.0_152
 set PATH=%JAVA_HOME%\bin;%PATH%
-set CLOUDSDK_PYTHON=c:\python27\python.exe
 
 cd github/appengine-plugins-core
 

--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -3,6 +3,7 @@
 REM Java 9 does not work with our builds right now, force java 8
 set JAVA_HOME=c:\program files\java\jdk1.8.0_152
 set PATH=%JAVA_HOME%\bin;%PATH%
+set CLOUDSDK_PYTHON=c:\python27\python.exe
 
 cd github/appengine-plugins-core
 

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponent.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponent.java
@@ -36,7 +36,9 @@ public enum SdkComponent {
   GCD_EMULATOR("gcd-emulator"),
   GSUTIL("gsutil"),
   KUBECTL("kubectl"),
-  PUBSUB_EMULATOR("pubsub-emulator");
+  PUBSUB_EMULATOR("pubsub-emulator"),
+  MINIKUBE("minikube"),
+  SKAFFOLD("skaffold");
 
   private final String value;
 


### PR DESCRIPTION
gcloud now manages these extra components. Cloud Code is going to migrate to using the gcloud managed versions of these instead of using its own management system.