### PR TITLE
ignore .checkstyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ target/
 .settings/*
 .metadata/*
 .DS_Store
+.checkstyle
+


### PR DESCRIPTION
@loosebazooka Eclipse has started autogenerating this file everywhere, littering the clients.