### PR TITLE
Add binary path to staging

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/configuration/AppYamlProjectStageConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/configuration/AppYamlProjectStageConfiguration.java
@@ -85,7 +85,7 @@ public class AppYamlProjectStageConfiguration {
   /**
    * Create a new builder for AppYamlProjectStageConfiguration.
    *
-   * @deprecated Use newBuilder().appEngineDirectory(appEngineDirectory).artifact(artifact)
+   * @deprecated Use builder().appEngineDirectory(appEngineDirectory).artifact(artifact)
    *     .stagingDirectory(stagingDirectory) instead.
    */
   @Deprecated

--- a/src/main/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStaging.java
+++ b/src/main/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStaging.java
@@ -88,10 +88,9 @@ public class AppYamlProjectStaging {
         }
         // I cannot deploy non-jars without custom entrypoints
         throw new AppEngineException(
-            "Cannot process application with runtime: java11,"
-                + " non-jar artifact: "
-                + config.getArtifact().toString()
-                + " must have a custom entrypoint defined in app.yaml");
+            "Cannot process application with runtime: java11."
+                + " A custom entrypoint must be defined in your app.yaml for non-jar artifact: "
+                + config.getArtifact().toString());
       }
       // I don't know how to deploy this
       throw new AppEngineException(
@@ -277,13 +276,13 @@ public class AppYamlProjectStaging {
   static boolean hasCustomEntrypoint(AppYamlProjectStageConfiguration config)
       throws IOException, AppEngineException {
     // verify that app.yaml that contains entrypoint:
-    Path appEngineDirectory = config.getAppEngineDirectory();
-    if (appEngineDirectory == null) {
+    if (config.getAppEngineDirectory() == null) {
       throw new AppEngineException("Invalid Staging Configuration: missing App Engine directory");
     }
     Path appYamlFile = config.getAppEngineDirectory().resolve(APP_YAML);
-    AppYaml appYaml = AppYaml.parse(Files.newInputStream(appYamlFile));
-    return (appYaml.getEntrypoint() != null);
+    try (InputStream input = Files.newInputStream(appYamlFile)) {
+      return AppYaml.parse(input).getEntrypoint() != null;
+    }
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStaging.java
+++ b/src/main/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStaging.java
@@ -221,7 +221,6 @@ public class AppYamlProjectStaging {
 
   private static void copyArtifact(AppYamlProjectStageConfiguration config, CopyService copyService)
       throws IOException, AppEngineException {
-    // Copy the JAR/WAR file to staging.
     Path artifact = config.getArtifact();
     if (Files.exists(artifact)) {
       Path stagingDirectory = config.getStagingDirectory();

--- a/src/test/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStagingTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStagingTest.java
@@ -16,10 +16,13 @@
 
 package com.google.cloud.tools.appengine.operations;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -44,7 +47,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /** Test the {@link AppYamlProjectStaging} functionality. */
@@ -96,8 +98,8 @@ public class AppYamlProjectStagingTest {
         StandardOpenOption.CREATE_NEW);
 
     // mock to watch internal calls
-    AppYamlProjectStaging mock = Mockito.mock(AppYamlProjectStaging.class);
-    Mockito.doCallRealMethod().when(mock).stageArchive(config);
+    AppYamlProjectStaging mock = mock(AppYamlProjectStaging.class);
+    doCallRealMethod().when(mock).stageArchive(config);
 
     mock.stageArchive(config);
     verify(mock).stageFlexibleArchive(config, "test_runtime");
@@ -111,8 +113,8 @@ public class AppYamlProjectStagingTest {
         StandardOpenOption.CREATE_NEW);
 
     // mock to watch internal calls
-    AppYamlProjectStaging mock = Mockito.mock(AppYamlProjectStaging.class);
-    Mockito.doCallRealMethod().when(mock).stageArchive(config);
+    AppYamlProjectStaging mock = mock(AppYamlProjectStaging.class);
+    doCallRealMethod().when(mock).stageArchive(config);
 
     mock.stageArchive(config);
     verify(mock).stageStandardArchive(config);
@@ -134,8 +136,8 @@ public class AppYamlProjectStagingTest {
         StandardOpenOption.CREATE_NEW);
 
     // mock to watch internal calls
-    AppYamlProjectStaging mock = Mockito.mock(AppYamlProjectStaging.class);
-    Mockito.doCallRealMethod().when(mock).stageArchive(config);
+    AppYamlProjectStaging mock = mock(AppYamlProjectStaging.class);
+    doCallRealMethod().when(mock).stageArchive(config);
 
     mock.stageArchive(config);
     verify(mock).stageStandardBinary(config);
@@ -144,11 +146,11 @@ public class AppYamlProjectStagingTest {
   @Test
   public void testStageArchive_java11BinaryWithoutEntrypoint()
       throws IOException, AppEngineException {
-    Path badArtifact = temporaryFolder.newFile("myscript.sh").toPath();
+    Path nonJarArtifact = temporaryFolder.newFile("myscript.sh").toPath();
     config =
         AppYamlProjectStageConfiguration.builder()
             .appEngineDirectory(appEngineDirectory)
-            .artifact(badArtifact)
+            .artifact(nonJarArtifact)
             .stagingDirectory(stagingDirectory)
             .extraFilesDirectories(extraFilesDirectories)
             .build();
@@ -164,10 +166,9 @@ public class AppYamlProjectStagingTest {
       testStaging.stageArchive(config);
       fail();
     } catch (AppEngineException ex) {
-      Assert.assertEquals(
-          "Cannot process application with runtime: java11, non-jar artifact: "
-              + badArtifact.toString()
-              + " must have a custom entrypoint defined in app.yaml",
+      assertEquals(
+          "Cannot process application with runtime: java11. A custom entrypoint must be defined in your app.yaml for non-jar artifact: "
+              + nonJarArtifact.toString(),
           ex.getMessage());
     }
   }
@@ -185,7 +186,7 @@ public class AppYamlProjectStagingTest {
       testStaging.stageArchive(config);
       fail();
     } catch (AppEngineException ex) {
-      Assert.assertEquals("Cannot process application with runtime: moose", ex.getMessage());
+      assertEquals("Cannot process application with runtime: moose", ex.getMessage());
     }
   }
 
@@ -333,7 +334,7 @@ public class AppYamlProjectStagingTest {
       AppYamlProjectStaging.copyExtraFiles(badExtraFilesConfig, copyService);
       fail();
     } catch (AppEngineException ex) {
-      Assert.assertEquals(
+      assertEquals(
           "Extra files directory does not exist. Location: " + extraFilesDirectory,
           ex.getMessage());
     }
@@ -356,7 +357,7 @@ public class AppYamlProjectStagingTest {
       AppYamlProjectStaging.copyExtraFiles(badExtraFilesConfig, copyService);
       fail();
     } catch (AppEngineException ex) {
-      Assert.assertEquals(
+      assertEquals(
           "Extra files location is not a directory. Location: " + extraFilesDirectory,
           ex.getMessage());
     }
@@ -424,8 +425,10 @@ public class AppYamlProjectStagingTest {
   public void testFindRuntime_malformedAppYaml() throws IOException {
 
     Path file = appEngineDirectory.resolve("app.yaml");
-    Files.createFile(file);
-    Files.write(file, ": m a l f o r m e d !".getBytes(StandardCharsets.UTF_8));
+    Files.write(
+        file,
+        ": m a l f o r m e d !".getBytes(StandardCharsets.UTF_8),
+        StandardOpenOption.CREATE_NEW);
 
     try {
       AppYamlProjectStaging.findRuntime(config);
@@ -436,19 +439,21 @@ public class AppYamlProjectStagingTest {
   }
 
   @Test
-  public void testEnsureCustomEntrypoint_success() throws IOException, AppEngineException {
+  public void testHasCustomEntrypoint_true() throws IOException, AppEngineException {
     Path file = appEngineDirectory.resolve("app.yaml");
-    Files.createFile(file);
-    Files.write(file, "entrypoint: custom custom".getBytes(StandardCharsets.UTF_8));
+    Files.write(
+        file,
+        "entrypoint: custom custom".getBytes(StandardCharsets.UTF_8),
+        StandardOpenOption.CREATE_NEW);
 
-    Assert.assertTrue(AppYamlProjectStaging.hasCustomEntrypoint(config));
+    assertTrue(AppYamlProjectStaging.hasCustomEntrypoint(config));
   }
 
   @Test
-  public void testEnsureCustomEntrypoint_fail() throws IOException, AppEngineException {
+  public void testHasCustomEntrypoint_false() throws IOException, AppEngineException {
     Path file = appEngineDirectory.resolve("app.yaml");
-    Files.createFile(file);
-    Files.write(file, "runtime: java".getBytes(StandardCharsets.UTF_8));
+    Files.write(
+        file, "runtime: java".getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE_NEW);
 
     Assert.assertFalse(AppYamlProjectStaging.hasCustomEntrypoint(config));
   }
@@ -465,7 +470,7 @@ public class AppYamlProjectStagingTest {
 
     verifyNoInteractions(copyService);
 
-    Assert.assertEquals(0, handler.getLogs().size());
+    assertEquals(0, handler.getLogs().size());
   }
 
   @Test
@@ -484,7 +489,7 @@ public class AppYamlProjectStagingTest {
             stagingDirectory.resolve("libs/simpleLib.jar"));
     verifyNoMoreInteractions(copyService);
 
-    Assert.assertEquals(0, handler.getLogs().size());
+    assertEquals(0, handler.getLogs().size());
   }
 
   @Test
@@ -505,9 +510,9 @@ public class AppYamlProjectStagingTest {
 
     // check for warning about missing jars
     List<LogRecord> logs = handler.getLogs();
-    Assert.assertEquals(1, logs.size());
-    Assert.assertEquals(Level.WARNING, logs.get(0).getLevel());
-    Assert.assertEquals(
+    assertEquals(1, logs.size());
+    assertEquals(Level.WARNING, logs.get(0).getLevel());
+    assertEquals(
         "Could not copy 'Class-Path' jar: "
             + Paths.get("src/test/resources/jars/libs/missing.jar")
             + " referenced in MANIFEST.MF",
@@ -535,9 +540,9 @@ public class AppYamlProjectStagingTest {
 
     // check for warning about overwriting jars
     List<LogRecord> logs = handler.getLogs();
-    Assert.assertEquals(1, logs.size());
-    Assert.assertEquals(Level.FINE, logs.get(0).getLevel());
-    Assert.assertEquals(
+    assertEquals(1, logs.size());
+    assertEquals(Level.FINE, logs.get(0).getLevel());
+    assertEquals(
         "Overwriting 'Class-Path' jar: "
             + simpleLibTarget
             + " with "
@@ -554,20 +559,20 @@ public class AppYamlProjectStagingTest {
     Path srcDir = root.resolve("srcDir");
     Files.createDirectory(srcDir);
     Path srcFile = srcDir.resolve("srcFile");
-    Files.createFile(srcFile);
-    Files.write(srcFile, "some content".getBytes(StandardCharsets.UTF_8));
+    Files.write(
+        srcFile, "some content".getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE_NEW);
 
     Path destDir = root.resolve("destDir");
     Files.createDirectory(destDir);
     Path destFile = destDir.resolve("destFile");
     Files.createFile(destFile);
 
-    Assert.assertTrue(Files.exists(destDir));
-    Assert.assertTrue(Files.exists(destFile));
+    assertTrue(Files.exists(destDir));
+    assertTrue(Files.exists(destFile));
 
     copier.copyFileAndReplace(srcFile, destFile);
 
-    Assert.assertArrayEquals(Files.readAllBytes(srcFile), Files.readAllBytes(destFile));
+    assertArrayEquals(Files.readAllBytes(srcFile), Files.readAllBytes(destFile));
   }
 
   @Test
@@ -578,8 +583,8 @@ public class AppYamlProjectStagingTest {
     Path srcDir = root.resolve("srcDir");
     Files.createDirectory(srcDir);
     Path srcFile = srcDir.resolve("srcFile");
-    Files.createFile(srcFile);
-    Files.write(srcFile, "some content".getBytes(StandardCharsets.UTF_8));
+    Files.write(
+        srcFile, "some content".getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE_NEW);
 
     Path destDir = root.resolve("destDir");
     Path destFile = destDir.resolve("destFile");
@@ -589,6 +594,6 @@ public class AppYamlProjectStagingTest {
 
     copier.copyFileAndReplace(srcFile, destFile);
 
-    Assert.assertArrayEquals(Files.readAllBytes(srcFile), Files.readAllBytes(destFile));
+    assertArrayEquals(Files.readAllBytes(srcFile), Files.readAllBytes(destFile));
   }
 }

--- a/src/test/java/com/google/cloud/tools/project/AppYamlTest.java
+++ b/src/test/java/com/google/cloud/tools/project/AppYamlTest.java
@@ -89,6 +89,12 @@ public class AppYamlTest {
   }
 
   @Test
+  public void testGetEntrypoint_nullBecauseNothing() throws AppEngineException {
+    InputStream appYaml = asStream("entrypoint:\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getRuntime());
+  }
+
+  @Test
   public void testGetEntrypoint_nullBecauseEmptyList() throws AppEngineException {
     InputStream appYaml = asStream("entrypoint: []\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getRuntime());

--- a/src/test/java/com/google/cloud/tools/project/AppYamlTest.java
+++ b/src/test/java/com/google/cloud/tools/project/AppYamlTest.java
@@ -78,7 +78,19 @@ public class AppYamlTest {
 
   @Test
   public void testGetEntrypoint_nullBecauseWrongType() throws AppEngineException {
-    InputStream appYaml = asStream("runtime: [goose, moose]\np2: v2");
+    InputStream appYaml = asStream("entrypoint: [goose, moose]\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getRuntime());
+  }
+
+  @Test
+  public void testGetEntrypoint_nullBecauseNull() throws AppEngineException {
+    InputStream appYaml = asStream("entrypoint: null\np2: v2");
+    Assert.assertNull(AppYaml.parse(appYaml).getRuntime());
+  }
+
+  @Test
+  public void testGetEntrypoint_nullBecauseEmptyList() throws AppEngineException {
+    InputStream appYaml = asStream("entrypoint: []\np2: v2");
     Assert.assertNull(AppYaml.parse(appYaml).getRuntime());
   }
 


### PR DESCRIPTION
part of #840
requires #839

Allows binaries in java11 build path (for example when building a quarkus native app)

Also changes the deprecated use of appYamlStaging builder in tests