### PR TITLE
Fix broken windows build by using Python3 for Cloud SDK

### DIFF
--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -9,6 +9,10 @@ cd github/appengine-plugins-core
 call gcloud.cmd components update --quiet
 call gcloud.cmd components install app-engine-java --quiet
 
+REM Latest Cloud SDK picks up c:\Python27\python.exe
+REM https://github.com/GoogleCloudPlatform/appengine-plugins-core/issues/851
+set CLOUDSDK_PYTHON=c:\Python37\python.exe
+
 call mvnw.cmd clean install cobertura:cobertura -B -U
 REM curl -s https://codecov.io/bash | bash
 

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
@@ -44,7 +44,7 @@ public class ManagedCloudSdkTest {
 
   @Rule public TemporaryFolder tempDir = new TemporaryFolder();
 
-  private static final String FIXED_VERSION = "286.0.0";
+  private static final String FIXED_VERSION = "314.0.0";
   private static final Map<String, String> EMPTY_MAP = Collections.emptyMap();
   private final MessageCollector testListener = new MessageCollector();
   private final ProgressListener testProgressListener = new NullProgressListener();

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/MessageCollector.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/MessageCollector.java
@@ -17,7 +17,7 @@
 package com.google.cloud.tools.managedcloudsdk;
 
 public class MessageCollector implements ConsoleListener {
-  StringBuilder output = new StringBuilder("");
+  private final StringBuilder output = new StringBuilder("");
 
   @Override
   public void console(String rawString) {


### PR DESCRIPTION
Unblocks #851.

Also advances the fixed version to 314 for testing SDK upgrading. (As long as it's lower than the latest (currently 318), we should be good to test upgrading.)