### PR TITLE
Add KPT to SdkComponent Enum

### DIFF
--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponent.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponent.java
@@ -38,7 +38,8 @@ public enum SdkComponent {
   KUBECTL("kubectl"),
   PUBSUB_EMULATOR("pubsub-emulator"),
   MINIKUBE("minikube"),
-  SKAFFOLD("skaffold");
+  SKAFFOLD("skaffold"),
+  KPT("kpt");
 
   private final String value;
 


### PR DESCRIPTION
Enabling Blueprints within the IDE requires the ability to download and manage kpt for the user. In Cloud Code for IntelliJ, we rely on the SdkComponent enum for installing managed dependencies via `gcloud components install <component>`. Therefore, we need to add kpt as an SdkComponent.