### PR TITLE
[ARM Support] Add support for override-components flag

### DIFF
--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
@@ -177,6 +177,17 @@ public class ManagedCloudSdk {
         managedSdkDirectory, version, osInfo, USER_AGENT_STRING, false, environmentVariables);
   }
 
+  public SdkInstaller newInstaller(String[] overrideComponents) {
+    return SdkInstaller.newInstaller(
+        managedSdkDirectory,
+        version,
+        osInfo,
+        USER_AGENT_STRING,
+        false,
+        overrideComponents,
+        Collections.emptyMap());
+  }
+
   public SdkComponentInstaller newComponentInstaller() {
     return SdkComponentInstaller.newComponentInstaller(osInfo.name(), getGcloudPath());
   }

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
@@ -182,9 +182,11 @@ public class ManagedCloudSdk {
    * of the installer script.
    *
    * @param overrideComponents array of gcloud components to install instead of the defaults
+   * @param environmentVariables environment variables used during installation script run
    * @return A {@link SdkInstaller}
    */
-  public SdkInstaller newInstaller(String[] overrideComponents) {
+  public SdkInstaller newInstaller(
+      String[] overrideComponents, Map<String, String> environmentVariables) {
     return SdkInstaller.newInstaller(
         managedSdkDirectory,
         version,
@@ -192,7 +194,7 @@ public class ManagedCloudSdk {
         USER_AGENT_STRING,
         false,
         overrideComponents,
-        Collections.emptyMap());
+        environmentVariables);
   }
 
   public SdkComponentInstaller newComponentInstaller() {

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
@@ -180,8 +180,8 @@ public class ManagedCloudSdk {
   }
 
   /**
-   * Create a new {@link SdkInstaller} with an array corresponding to the --override-components flag
-   * of the installer script.
+   * Create a new {@link SdkInstaller} with gcloud components to install (override) and
+   * environment variables to use while running the installer script.
    *
    * @param overrideComponents gcloud components to install instead of the defaults
    * @param environmentVariables environment variables used during installation script run

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
@@ -177,6 +177,13 @@ public class ManagedCloudSdk {
         managedSdkDirectory, version, osInfo, USER_AGENT_STRING, false, environmentVariables);
   }
 
+  /**
+   * Create a new {@link SdkInstaller} with an array corresponding to the --override-components
+   * flag of the installer script.
+   *
+   * @param overrideComponents array of gcloud components to install instead of the defaults
+   * @return A {@link SdkInstaller}
+   */
   public SdkInstaller newInstaller(String[] overrideComponents) {
     return SdkInstaller.newInstaller(
         managedSdkDirectory,

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 /** A manager for installing, configuring and updating the Cloud SDK. */
 public class ManagedCloudSdk {
@@ -187,7 +188,7 @@ public class ManagedCloudSdk {
    * @return a {@link SdkInstaller}
    */
   public SdkInstaller newInstaller(
-      Set<String> overrideComponents, Map<String, String> environmentVariables) {
+      @Nullable Set<String> overrideComponents, Map<String, String> environmentVariables) {
     return SdkInstaller.newInstaller(
         managedSdkDirectory,
         version,

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.logging.Logger;
 
 /** A manager for installing, configuring and updating the Cloud SDK. */
@@ -181,12 +182,12 @@ public class ManagedCloudSdk {
    * Create a new {@link SdkInstaller} with an array corresponding to the --override-components flag
    * of the installer script.
    *
-   * @param overrideComponents array of gcloud components to install instead of the defaults
+   * @param overrideComponents gcloud components to install instead of the defaults
    * @param environmentVariables environment variables used during installation script run
-   * @return A {@link SdkInstaller}
+   * @return a {@link SdkInstaller}
    */
   public SdkInstaller newInstaller(
-      String[] overrideComponents, Map<String, String> environmentVariables) {
+      Set<String> overrideComponents, Map<String, String> environmentVariables) {
     return SdkInstaller.newInstaller(
         managedSdkDirectory,
         version,

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
@@ -178,8 +178,8 @@ public class ManagedCloudSdk {
   }
 
   /**
-   * Create a new {@link SdkInstaller} with an array corresponding to the --override-components
-   * flag of the installer script.
+   * Create a new {@link SdkInstaller} with an array corresponding to the --override-components flag
+   * of the installer script.
    *
    * @param overrideComponents array of gcloud components to install instead of the defaults
    * @return A {@link SdkInstaller}

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdk.java
@@ -180,8 +180,8 @@ public class ManagedCloudSdk {
   }
 
   /**
-   * Create a new {@link SdkInstaller} with gcloud components to install (override) and
-   * environment variables to use while running the installer script.
+   * Create a new {@link SdkInstaller} with gcloud components to install (override) and environment
+   * variables to use while running the installer script.
    *
    * @param overrideComponents gcloud components to install instead of the defaults
    * @param environmentVariables environment variables used during installation script run

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Installer.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Installer.java
@@ -24,9 +24,9 @@ import com.google.cloud.tools.managedcloudsdk.command.CommandRunner;
 import com.google.common.annotations.VisibleForTesting;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /** Installer for running install scripts in a Cloud SDK download. */
@@ -39,7 +39,7 @@ final class Installer {
   private final ConsoleListener consoleListener;
   private final CommandRunner commandRunner;
 
-  private @Nullable String[] overrideComponents = null;
+  @Nullable private final Set<String> overrideComponents;
 
   /** Instantiated by {@link InstallerFactory}. */
   Installer(
@@ -64,7 +64,7 @@ final class Installer {
       Path installedSdkRoot,
       InstallScriptProvider installScriptProvider,
       boolean usageReporting,
-      @Nullable String[] overrideComponents,
+      @Nullable Set<String> overrideComponents,
       ProgressListener progressListener,
       ConsoleListener consoleListener,
       CommandRunner commandRunner) {
@@ -89,8 +89,7 @@ final class Installer {
 
     if (overrideComponents != null) {
       command.add("--override-components");
-
-      Collections.addAll(command, overrideComponents);
+      command.addAll(overrideComponents);
     }
 
     Path workingDirectory = installedSdkRoot.getParent();

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Installer.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/Installer.java
@@ -24,8 +24,10 @@ import com.google.cloud.tools.managedcloudsdk.command.CommandRunner;
 import com.google.common.annotations.VisibleForTesting;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /** Installer for running install scripts in a Cloud SDK download. */
 final class Installer {
@@ -37,6 +39,8 @@ final class Installer {
   private final ConsoleListener consoleListener;
   private final CommandRunner commandRunner;
 
+  private @Nullable String[] overrideComponents = null;
+
   /** Instantiated by {@link InstallerFactory}. */
   Installer(
       Path installedSdkRoot,
@@ -45,9 +49,29 @@ final class Installer {
       ProgressListener progressListener,
       ConsoleListener consoleListener,
       CommandRunner commandRunner) {
+    this(
+        installedSdkRoot,
+        installScriptProvider,
+        usageReporting,
+        null,
+        progressListener,
+        consoleListener,
+        commandRunner);
+  }
+
+  /** Instantiated by {@link InstallerFactory}. */
+  Installer(
+      Path installedSdkRoot,
+      InstallScriptProvider installScriptProvider,
+      boolean usageReporting,
+      @Nullable String[] overrideComponents,
+      ProgressListener progressListener,
+      ConsoleListener consoleListener,
+      CommandRunner commandRunner) {
     this.installedSdkRoot = installedSdkRoot;
     this.installScriptProvider = installScriptProvider;
     this.usageReporting = usageReporting;
+    this.overrideComponents = overrideComponents;
     this.progressListener = progressListener;
     this.consoleListener = consoleListener;
     this.commandRunner = commandRunner;
@@ -62,6 +86,12 @@ final class Installer {
     command.add("--command-completion=false"); // don't add command completion
     command.add("--quiet"); // don't accept user input during install
     command.add("--usage-reporting=" + usageReporting); // usage reporting passthrough
+
+    if (overrideComponents != null) {
+      command.add("--override-components");
+
+      Collections.addAll(command, overrideComponents);
+    }
 
     Path workingDirectory = installedSdkRoot.getParent();
     Map<String, String> installerEnvironment = installScriptProvider.getScriptEnvironment();

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/InstallerFactory.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/InstallerFactory.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.managedcloudsdk.command.CommandRunner;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /** {@link Installer} Factory. */
@@ -30,17 +31,18 @@ final class InstallerFactory {
 
   private final OsInfo osInfo;
   private final boolean usageReporting;
-  private final @Nullable String[] overrideComponents;
+  private final @Nullable Set<String> overrideComponents;
 
   /**
    * Creates a new factory.
    *
    * @param osInfo the operating system of the computer this script is running on
-   * @param usageReporting enable or disable client side usage reporting {@code true} is enabled,
+   * @param usageReporting enable or disable client side usage reporting. {@code true} is enabled,
    *     {@code false} is disabled
-   * @param overrideComponents array of gcloud components to install instead of the defaults
+   * @param overrideComponents gcloud components to install instead of the defaults
    */
-  InstallerFactory(OsInfo osInfo, boolean usageReporting, @Nullable String[] overrideComponents) {
+  InstallerFactory(
+      OsInfo osInfo, boolean usageReporting, @Nullable Set<String> overrideComponents) {
     this.osInfo = osInfo;
     this.usageReporting = usageReporting;
     this.overrideComponents = overrideComponents;
@@ -50,7 +52,7 @@ final class InstallerFactory {
    * Creates a new factory.
    *
    * @param osInfo the operating system of the computer this script is running on
-   * @param usageReporting enable or disable client side usage reporting {@code true} is enabled,
+   * @param usageReporting enable or disable client side usage reporting. {@code true} is enabled,
    *     {@code false} is disabled
    */
   InstallerFactory(OsInfo osInfo, boolean usageReporting) {

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/InstallerFactory.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/InstallerFactory.java
@@ -31,7 +31,7 @@ final class InstallerFactory {
 
   private final OsInfo osInfo;
   private final boolean usageReporting;
-  private final @Nullable Set<String> overrideComponents;
+  @Nullable private final Set<String> overrideComponents;
 
   /**
    * Creates a new factory.

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/InstallerFactory.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/InstallerFactory.java
@@ -23,12 +23,28 @@ import com.google.cloud.tools.managedcloudsdk.command.CommandRunner;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /** {@link Installer} Factory. */
 final class InstallerFactory {
 
   private final OsInfo osInfo;
   private final boolean usageReporting;
+  private final @Nullable String[] overrideComponents;
+
+  /**
+   * Creates a new factory.
+   *
+   * @param osInfo the operating system of the computer this script is running on
+   * @param usageReporting enable or disable client side usage reporting {@code true} is enabled,
+   *     {@code false} is disabled
+   * @param overrideComponents array of gcloud components to install instead of the defaults
+   */
+  InstallerFactory(OsInfo osInfo, boolean usageReporting, @Nullable String[] overrideComponents) {
+    this.osInfo = osInfo;
+    this.usageReporting = usageReporting;
+    this.overrideComponents = overrideComponents;
+  }
 
   /**
    * Creates a new factory.
@@ -38,8 +54,7 @@ final class InstallerFactory {
    *     {@code false} is disabled
    */
   InstallerFactory(OsInfo osInfo, boolean usageReporting) {
-    this.osInfo = osInfo;
-    this.usageReporting = usageReporting;
+    this(osInfo, usageReporting, null);
   }
 
   /**
@@ -61,6 +76,7 @@ final class InstallerFactory {
         installedSdkRoot,
         getInstallScriptProvider(environmentVariables),
         usageReporting,
+        overrideComponents,
         progressListener,
         consoleListener,
         CommandRunner.newRunner());

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstaller.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstaller.java
@@ -158,7 +158,7 @@ public class SdkInstaller {
   /**
    * Configure and create a new Installer instance.
    *
-   * @param managedSdkDirectory home directory of google cloud java managed cloud SDKs
+   * @param managedSdkDirectory directory where the Cloud SDK will be installed
    * @param version version of the Cloud SDK to install
    * @param osInfo target operating system for installation
    * @param userAgentString user agent string for https requests
@@ -187,7 +187,7 @@ public class SdkInstaller {
   /**
    * Configure and create a new Installer instance.
    *
-   * @param managedSdkDirectory home directory of google cloud java managed cloud SDKs
+   * @param managedSdkDirectory directory where the Cloud SDK will be installed
    * @param version version of the Cloud SDK to install
    * @param osInfo target operating system for installation
    * @param userAgentString user agent string for https requests

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstaller.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstaller.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -158,11 +159,11 @@ public class SdkInstaller {
    * Configure and create a new Installer instance.
    *
    * @param managedSdkDirectory home directory of google cloud java managed cloud SDKs
-   * @param version version of the Cloud SDK we want to install
+   * @param version version of the Cloud SDK to install
    * @param osInfo target operating system for installation
    * @param userAgentString user agent string for https requests
    * @param usageReporting enable client side usage reporting on gcloud
-   * @param environmentVariables Map of additional environment variables to be passed on to the
+   * @param environmentVariables map of additional environment variables to be passed to the
    *     installer process (proxy settings, etc.)
    * @return a new configured Cloud SDK Installer
    */
@@ -187,13 +188,13 @@ public class SdkInstaller {
    * Configure and create a new Installer instance.
    *
    * @param managedSdkDirectory home directory of google cloud java managed cloud SDKs
-   * @param version version of the Cloud SDK we want to install
+   * @param version version of the Cloud SDK to install
    * @param osInfo target operating system for installation
    * @param userAgentString user agent string for https requests
    * @param usageReporting enable client side usage reporting on gcloud
-   * @param environmentVariables Map of additional environment variables to be passed on to the
+   * @param environmentVariables map of additional environment variables to be passed to the
    *     installer process (proxy settings, etc.)
-   * @param overrideComponents array of gcloud components to install instead of the defaults
+   * @param overrideComponents gcloud components to install instead of the defaults
    * @return a new configured Cloud SDK Installer
    */
   public static SdkInstaller newInstaller(
@@ -202,7 +203,7 @@ public class SdkInstaller {
       OsInfo osInfo,
       String userAgentString,
       boolean usageReporting,
-      @Nullable String[] overrideComponents,
+      @Nullable Set<String> overrideComponents,
       Map<String, String> environmentVariables) {
     DownloaderFactory downloaderFactory = new DownloaderFactory(userAgentString);
     ExtractorFactory extractorFactory = new ExtractorFactory();

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstaller.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstaller.java
@@ -173,11 +173,44 @@ public class SdkInstaller {
       String userAgentString,
       boolean usageReporting,
       Map<String, String> environmentVariables) {
+    return SdkInstaller.newInstaller(
+        managedSdkDirectory,
+        version,
+        osInfo,
+        userAgentString,
+        usageReporting,
+        null,
+        environmentVariables);
+  }
+
+  /**
+   * Configure and create a new Installer instance.
+   *
+   * @param managedSdkDirectory home directory of google cloud java managed cloud SDKs
+   * @param version version of the Cloud SDK we want to install
+   * @param osInfo target operating system for installation
+   * @param userAgentString user agent string for https requests
+   * @param usageReporting enable client side usage reporting on gcloud
+   * @param environmentVariables Map of additional environment variables to be passed on to the
+   *     installer process (proxy settings, etc.)
+   * @param overrideComponents array of gcloud components to install instead of the defaults
+   * @return a new configured Cloud SDK Installer
+   */
+  public static SdkInstaller newInstaller(
+      Path managedSdkDirectory,
+      Version version,
+      OsInfo osInfo,
+      String userAgentString,
+      boolean usageReporting,
+      @Nullable String[] overrideComponents,
+      Map<String, String> environmentVariables) {
     DownloaderFactory downloaderFactory = new DownloaderFactory(userAgentString);
     ExtractorFactory extractorFactory = new ExtractorFactory();
 
     InstallerFactory installerFactory =
-        version == Version.LATEST ? new InstallerFactory(osInfo, usageReporting) : null;
+        version == Version.LATEST
+            ? new InstallerFactory(osInfo, usageReporting, overrideComponents)
+            : null;
 
     FileResourceProviderFactory fileResourceProviderFactory =
         new FileResourceProviderFactory(version, osInfo, managedSdkDirectory);

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import org.junit.Assert;
@@ -152,7 +153,7 @@ public class ManagedCloudSdkTest {
     Assert.assertFalse(testSdk.isUpToDate());
 
     testSdk
-        .newInstaller(new String[] {"app-engine-java"}, Collections.emptyMap())
+        .newInstaller(new HashSet<>(Arrays.asList("app-engine-java")), Collections.emptyMap())
         .install(testProgressListener, testListener);
 
     Assert.assertTrue(testSdk.isInstalled());

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
@@ -140,6 +140,45 @@ public class ManagedCloudSdkTest {
     Assert.assertTrue(testSdk.isUpToDate());
   }
 
+  @Test
+  public void testManagedCloudSdk_latestWithOverrides()
+      throws UnsupportedOsException, ManagedSdkVerificationException,
+      ManagedSdkVersionMismatchException, InterruptedException, CommandExecutionException,
+      CommandExitException, IOException, SdkInstallerException {
+    ManagedCloudSdk testSdk =
+        new ManagedCloudSdk(Version.LATEST, userHome, OsInfo.getSystemOsInfo());
+
+    Assert.assertFalse(testSdk.isInstalled());
+    Assert.assertFalse(testSdk.isUpToDate());
+
+    testSdk.newInstaller(
+        new String[]{"app-engine-java"}, Collections.emptyMap()
+    ).install(testProgressListener, testListener);
+
+    Assert.assertTrue(testSdk.isInstalled());
+    Assert.assertTrue(testSdk.isUpToDate());
+
+    // Forcibly downgrade the cloud SDK so we can test updating.
+    downgradeCloudSdk(testSdk);
+
+    Assert.assertTrue(testSdk.isInstalled());
+    Assert.assertFalse(testSdk.isUpToDate());
+
+    testSdk.newUpdater().update(testProgressListener, testListener);
+
+    Assert.assertTrue(testSdk.isInstalled());
+    Assert.assertTrue(testSdk.hasComponent(testComponent));
+    Assert.assertTrue(testSdk.isUpToDate());
+
+    testSdk
+        .newComponentInstaller()
+        .installComponent(testComponent, testProgressListener, testListener);
+
+    Assert.assertTrue(testSdk.isInstalled());
+    Assert.assertTrue(testSdk.hasComponent(testComponent));
+    Assert.assertTrue(testSdk.isUpToDate());
+  }
+
   private static final Path CLOUD_SDK_PARTIAL_PATH =
       Paths.get("google-cloud-tools-java/managed-cloud-sdk");
   private static final Path CLOUD_SDK_PARTIAL_PATH_WINDOWS = Paths.get("google/ct4j-cloud-sdk");

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
@@ -157,6 +157,7 @@ public class ManagedCloudSdkTest {
 
     Assert.assertTrue(testSdk.isInstalled());
     Assert.assertTrue(testSdk.isUpToDate());
+    Assert.assertTrue(testSdk.hasComponent(testComponent));
   }
 
   private static final Path CLOUD_SDK_PARTIAL_PATH =

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
@@ -157,26 +157,6 @@ public class ManagedCloudSdkTest {
 
     Assert.assertTrue(testSdk.isInstalled());
     Assert.assertTrue(testSdk.isUpToDate());
-
-    // Forcibly downgrade the cloud SDK so we can test updating.
-    downgradeCloudSdk(testSdk);
-
-    Assert.assertTrue(testSdk.isInstalled());
-    Assert.assertFalse(testSdk.isUpToDate());
-
-    testSdk.newUpdater().update(testProgressListener, testListener);
-
-    Assert.assertTrue(testSdk.isInstalled());
-    Assert.assertTrue(testSdk.hasComponent(testComponent));
-    Assert.assertTrue(testSdk.isUpToDate());
-
-    testSdk
-        .newComponentInstaller()
-        .installComponent(testComponent, testProgressListener, testListener);
-
-    Assert.assertTrue(testSdk.isInstalled());
-    Assert.assertTrue(testSdk.hasComponent(testComponent));
-    Assert.assertTrue(testSdk.isUpToDate());
   }
 
   private static final Path CLOUD_SDK_PARTIAL_PATH =

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
@@ -143,17 +143,17 @@ public class ManagedCloudSdkTest {
   @Test
   public void testManagedCloudSdk_latestWithOverrides()
       throws UnsupportedOsException, ManagedSdkVerificationException,
-      ManagedSdkVersionMismatchException, InterruptedException, CommandExecutionException,
-      CommandExitException, IOException, SdkInstallerException {
+          ManagedSdkVersionMismatchException, InterruptedException, CommandExecutionException,
+          CommandExitException, IOException, SdkInstallerException {
     ManagedCloudSdk testSdk =
         new ManagedCloudSdk(Version.LATEST, userHome, OsInfo.getSystemOsInfo());
 
     Assert.assertFalse(testSdk.isInstalled());
     Assert.assertFalse(testSdk.isUpToDate());
 
-    testSdk.newInstaller(
-        new String[]{"app-engine-java"}, Collections.emptyMap()
-    ).install(testProgressListener, testListener);
+    testSdk
+        .newInstaller(new String[] {"app-engine-java"}, Collections.emptyMap())
+        .install(testProgressListener, testListener);
 
     Assert.assertTrue(testSdk.isInstalled());
     Assert.assertTrue(testSdk.isUpToDate());

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/InstallerTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/InstallerTest.java
@@ -24,8 +24,10 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -94,12 +96,42 @@ public class InstallerTest {
     Mockito.verifyNoMoreInteractions(mockCommandRunner);
   }
 
+  @Test
+  public void testCall_withOverrideComponents() throws Exception {
+    String[] overrides = new String[] {"mycomponent", "myothercomponent"};
+
+    new Installer(
+            fakeSdkRoot,
+            mockInstallScriptProvider,
+            true,
+            overrides,
+            mockProgressListener,
+            mockConsoleListener,
+            mockCommandRunner)
+        .install();
+
+    Mockito.verify(mockCommandRunner)
+        .run(expectedCommand(true, overrides), sdkParentDirectory, fakeEnv, mockConsoleListener);
+    Mockito.verifyNoMoreInteractions(mockCommandRunner);
+  }
+
   private List<String> expectedCommand(boolean usageReporting) {
+    return expectedCommand(usageReporting, null);
+  }
+
+  private List<String> expectedCommand(
+      boolean usageReporting, @Nullable String[] overrideComponents) {
     List<String> command = new ArrayList<>(fakeCommand);
     command.add("--path-update=false");
     command.add("--command-completion=false");
     command.add("--quiet");
     command.add("--usage-reporting=" + usageReporting);
+
+    if (overrideComponents != null) {
+      command.add("--override-components");
+
+      Collections.addAll(command, overrideComponents);
+    }
 
     return command;
   }

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/InstallerTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/InstallerTest.java
@@ -24,9 +24,10 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Rule;
@@ -98,7 +99,7 @@ public class InstallerTest {
 
   @Test
   public void testCall_withOverrideComponents() throws Exception {
-    String[] overrides = new String[] {"mycomponent", "myothercomponent"};
+    Set<String> overrides = new HashSet<>(Arrays.asList("mycomponent", "myothercomponent"));
 
     new Installer(
             fakeSdkRoot,
@@ -120,7 +121,7 @@ public class InstallerTest {
   }
 
   private List<String> expectedCommand(
-      boolean usageReporting, @Nullable String[] overrideComponents) {
+      boolean usageReporting, @Nullable Set<String> overrideComponents) {
     List<String> command = new ArrayList<>(fakeCommand);
     command.add("--path-update=false");
     command.add("--command-completion=false");
@@ -129,8 +130,7 @@ public class InstallerTest {
 
     if (overrideComponents != null) {
       command.add("--override-components");
-
-      Collections.addAll(command, overrideComponents);
+      command.addAll(overrideComponents);
     }
 
     return command;


### PR DESCRIPTION
Currently, the Managed Cloud SDK installer runs the installation script, which automatically installs the `["core", "gcloud-deps", "bq", "gcloud", "gsutil", "anthoscli", "kuberun"]` components. Of these, `anthoscli` and `kuberun` do not have native arm binaries and thus can only be installed if rosetta is installed.

For Cloud Code in IntelliJ, our goal for our March release is to not require the user to install rosetta in order to use our plugin. Allowing the client to specify the `--override-components` flag lets us specify which components we want to install while the offending components are updated (which may not be until after march)
* [kuberun cl](https://critique-ng.corp.google.com/cl/361621308)
* [anthoscli cl](https://gke-internal-review.googlesource.com/c/PaaSKit/anthos-cli/+/240084)


Example Usage:

```kt
val managedCloudSdk = ManagedCloudSdk.newManagedSdk()
val overrideComponents = arrayOf("core", "gcloud-deps", "bq", "gcloud", "gsutil")
val environmentVariables = mapOf<String, String>()

managedCloudSdk
  .newInstaller(overrideComponents, environmentVariables)
  .install(progressListener, sdkConsoleListener)
```