### PR TITLE
Adding support for installing multiple gcloud components

### DIFF
--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstaller.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstaller.java
@@ -26,7 +26,7 @@ import com.google.cloud.tools.managedcloudsdk.command.CommandRunner;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.nio.file.Path;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -88,7 +88,14 @@ public class SdkComponentInstaller {
 
     Path workingDirectory = gcloudPath.getRoot();
 
-    List<String> command = Arrays.asList(gcloudPath.toString(), "components", "install");
+    List<String> command =
+        new ArrayList<String>() {
+          {
+            add(gcloudPath.toString());
+            add("components");
+            add("install");
+          }
+        };
     components.forEach(component -> command.add(component.toString()));
     command.add("--quiet");
 

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstaller.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstaller.java
@@ -86,13 +86,12 @@ public class SdkComponentInstaller {
       environment = pythonCopier.copyPython();
     }
 
-    Path workingDirectory = gcloudPath.getRoot();
-
     List<String> command = new ArrayList<>();
     Collections.addAll(command, gcloudPath.toString(), "components", "install");
     components.forEach(component -> command.add(component.toString()));
     command.add("--quiet");
 
+    Path workingDirectory = gcloudPath.getRoot();
     commandRunner.run(command, workingDirectory, environment, consoleListener);
     progressListener.done();
   }

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstaller.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstaller.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /** Install an SDK component. */
@@ -75,13 +76,9 @@ public class SdkComponentInstaller {
       ConsoleListener consoleListener)
       throws InterruptedException, CommandExitException, CommandExecutionException {
 
-    String message;
-    if (components.size() == 1) {
-      message = "Installing " + components.get(0).toString();
-    } else {
-      message = "Installing components";
-    }
-
+    String message =
+        "Installing "
+            + components.stream().map(SdkComponent::toString).collect(Collectors.joining(", "));
     progressListener.start(message, ProgressListener.UNKNOWN);
 
     Map<String, String> environment = null;

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstaller.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstaller.java
@@ -88,14 +88,8 @@ public class SdkComponentInstaller {
 
     Path workingDirectory = gcloudPath.getRoot();
 
-    List<String> command =
-        new ArrayList<String>() {
-          {
-            add(gcloudPath.toString());
-            add("components");
-            add("install");
-          }
-        };
+    List<String> command = new ArrayList<>();
+    Collections.addAll(command, gcloudPath.toString(), "components", "install");
     components.forEach(component -> command.add(component.toString()));
     command.add("--quiet");
 

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstaller.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponentInstaller.java
@@ -27,6 +27,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -58,8 +59,30 @@ public class SdkComponentInstaller {
   public void installComponent(
       SdkComponent component, ProgressListener progressListener, ConsoleListener consoleListener)
       throws InterruptedException, CommandExitException, CommandExecutionException {
+    installComponents(Collections.singletonList(component), progressListener, consoleListener);
+  }
 
-    progressListener.start("Installing " + component.toString(), ProgressListener.UNKNOWN);
+  /**
+   * Install components.
+   *
+   * @param components list of components to install
+   * @param progressListener listener to action progress feedback
+   * @param consoleListener listener to process console feedback
+   */
+  public void installComponents(
+      List<SdkComponent> components,
+      ProgressListener progressListener,
+      ConsoleListener consoleListener)
+      throws InterruptedException, CommandExitException, CommandExecutionException {
+
+    String message;
+    if (components.size() == 1) {
+      message = "Installing " + components.get(0).toString();
+    } else {
+      message = "Installing components";
+    }
+
+    progressListener.start(message, ProgressListener.UNKNOWN);
 
     Map<String, String> environment = null;
     if (pythonCopier != null) {
@@ -67,9 +90,11 @@ public class SdkComponentInstaller {
     }
 
     Path workingDirectory = gcloudPath.getRoot();
-    List<String> command =
-        Arrays.asList(
-            gcloudPath.toString(), "components", "install", component.toString(), "--quiet");
+
+    List<String> command = Arrays.asList(gcloudPath.toString(), "components", "install");
+    components.forEach(component -> command.add(component.toString()));
+    command.add("--quiet");
+
     commandRunner.run(command, workingDirectory, environment, consoleListener);
     progressListener.done();
   }


### PR DESCRIPTION
**Summary**

- [discussion context](https://github.com/GoogleCloudPlatform/cloud-code-intellij-internal/pull/3615#discussion_r590688062)

Followed the docs to update the command to accept multiple components during install
- https://cloud.google.com/sdk/gcloud/reference/components/install
- e.g. `gcloud components install alpha beta --quiet`

**Ran the following:**
- `mvn fmt:format`
- `mvn clean install -DskipTests`
  - Could not get the tests to compile on a clean main branch, so skipped them

**Testing**
- Did not manually test yet