### PR TITLE
Release 0.9.4 Followup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>appengine-plugins-core</artifactId>
-  <version>0.9.4-SNAPSHOT</version>
+  <version>0.9.4</version>
 
   <name>App Engine Plugins Core Library</name>
   <description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>appengine-plugins-core</artifactId>
-  <version>0.9.4</version>
+  <version>0.9.5-SNAPSHOT</version>
 
   <name>App Engine Plugins Core Library</name>
   <description>


### PR DESCRIPTION
- Updating to 0.9.5
- [Release Instructions](https://g3doc.corp.google.com/company/teams/cloud-java/tools/developers/releasing.md?cl=head#releasing-via-rapid)
- Only merge after 0.9.4 is released: [build status](https://rapid.corp.google.com/#/release/cloud-java-tools-appengine-plugins-core-kokoro-release/v0.9.4?showInactive=false)

**TODO**
- [x] Verify: The released artifact should show up at https://repo1.maven.org/maven2/com/google/cloud/tools/. It should then be updated on [Maven Repository](https://mvnrepository.com/artifact/com.google.cloud.tools) in a few hours.
- [x] Post a message to [gae-docs](https://groups.google.com/a/google.com/g/gae-docs) list to notify the doc writers to update the public docs.
