### PR TITLE
Fixing cloud sdk install progress bar display time

### DIFF
--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstaller.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstaller.java
@@ -106,7 +106,7 @@ public class SdkInstaller {
         downloaderFactory.newDownloader(
             fileResourceProvider.getArchiveSource(),
             fileResourceProvider.getArchiveDestination(),
-            progressListener.newChild(100));
+            progressListener);
     downloader.download();
     if (!Files.isRegularFile(fileResourceProvider.getArchiveDestination())) {
       throw new SdkInstallerException(
@@ -120,7 +120,7 @@ public class SdkInstaller {
           .newExtractor(
               fileResourceProvider.getArchiveDestination(),
               fileResourceProvider.getArchiveExtractionDestination(),
-              progressListener.newChild(100))
+              progressListener)
           .extract();
       if (!Files.isDirectory(fileResourceProvider.getExtractedSdkHome())) {
         throw new SdkInstallerException(
@@ -138,7 +138,7 @@ public class SdkInstaller {
       installerFactory
           .newInstaller(
               fileResourceProvider.getExtractedSdkHome(),
-              progressListener.newChild(100),
+              progressListener,
               consoleListener,
               environmentVariables)
           .install();

--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstaller.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstaller.java
@@ -99,7 +99,7 @@ public class SdkInstaller {
           RecursiveDeleteOption.ALLOW_INSECURE);
     }
 
-    progressListener.start("Installing Cloud SDK", installerFactory != null ? 300 : 200);
+    progressListener.start("Installing Cloud SDK", ProgressListener.UNKNOWN);
 
     // download and verify
     Downloader downloader =

--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstallerTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/install/SdkInstallerTest.java
@@ -91,8 +91,6 @@ public class SdkInstallerTest {
     Mockito.when(fileResourceProviderFactory.newFileResourceProvider())
         .thenReturn(fakeFileResourceProvider);
 
-    Mockito.when(progressListener.newChild(Mockito.any(Long.class))).thenReturn(progressListener);
-
     // SUCCESS MOCKS
     Mockito.doReturn(successfulDownloader)
         .when(successfulDownloaderFactory)


### PR DESCRIPTION
**Summary**

- The progress bar for installing the cloud sdk does not appear, even though it is being installed
- Both updating the cloud sdk (`SdkUpdater::update`) and installing components (`SdkComponentInstaller::installComponent`) use `ProgressListener.UNKNOWN` while installing the SDK (`SdkInstaller::install`) sets the progress time to 200 or 300 ms.
- Setting the time to `ProgressListener.UNKNOWN` and removing the child progress listeners prevent the progress bar from disappearing.
- [context](https://github.com/GoogleCloudPlatform/cloud-code-intellij-internal/issues/3688)

![image](https://user-images.githubusercontent.com/58699538/113021030-2ab7d000-9151-11eb-964d-753777435ce0.png)

![progress](https://user-images.githubusercontent.com/58699538/113021048-2ee3ed80-9151-11eb-9d33-9b88ec44f595.gif)

**Ran the following:**
- `mvn fmt:format`
- `mvn clean install`, `mvn clean install -DskipTests`

**Testing**
-  [x] Build snapshot JAR and ran in Cloud Code using these [instructions](https://github.com/GoogleCloudPlatform/cloud-code-intellij-internal/wiki/Dependencies#app-engine-plugins-core)

**Release Process to Follow**
- https://g3doc.corp.google.com/company/teams/cloud-java/tools/developers/releasing.md?cl=head#releasing-via-rapid