### PR TITLE
Adding the gke-gcloud-auth-plugin component

### DIFF
--- a/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponent.java
+++ b/src/main/java/com/google/cloud/tools/managedcloudsdk/components/SdkComponent.java
@@ -39,7 +39,8 @@ public enum SdkComponent {
   PUBSUB_EMULATOR("pubsub-emulator"),
   MINIKUBE("minikube"),
   SKAFFOLD("skaffold"),
-  KPT("kpt");
+  KPT("kpt"),
+  GKE_GCLOUD_AUTH_PLUGIN("gke-gcloud-auth-plugin");
 
   private final String value;
 


### PR DESCRIPTION
> The `gke-gcloud-auth-plugin` will be rolling out to all customers in Q2 2022 (with MSAs etc), so we will need to install this component for GKE cluster access. It is safe for us to start installing this for users now: no need to wait

context from @briandealwis 

Announcement: https://groups.google.com/a/google.com/g/containers-discuss/c/TorLPo6FOwc/m/4-fPMFP2AgAJ