### PR TITLE
Support Java 17 runtime

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStaging.java
+++ b/src/main/java/com/google/cloud/tools/appengine/operations/AppYamlProjectStaging.java
@@ -76,7 +76,7 @@ public class AppYamlProjectStaging {
         stageFlexibleArchive(config, runtime);
         return;
       }
-      if ("java11".equals(runtime)) {
+      if ("java11".equals(runtime) || "java17".equals(runtime)) {
         boolean isJar = config.getArtifact().getFileName().toString().endsWith(".jar");
         if (isJar) {
           stageStandardArchive(config);
@@ -88,7 +88,7 @@ public class AppYamlProjectStaging {
         }
         // I cannot deploy non-jars without custom entrypoints
         throw new AppEngineException(
-            "Cannot process application with runtime: java11."
+            "Cannot process application with runtime: java11/java17."
                 + " A custom entrypoint must be defined in your app.yaml for non-jar artifact: "
                 + config.getArtifact().toString());
       }


### PR DESCRIPTION
According to your [own documentation](https://cloud.google.com/appengine/docs/standard/java-gen2/runtime#java-11), Java 17 is now supported in the App Engine Standard Environment. 

However, the Gradle plugin did not accept the `runtime: java17` value in `app.yaml`.