### PR TITLE
Update gcloud to a recent version

### DIFF
--- a/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/managedcloudsdk/ManagedCloudSdkTest.java
@@ -45,7 +45,7 @@ public class ManagedCloudSdkTest {
 
   @Rule public TemporaryFolder tempDir = new TemporaryFolder();
 
-  private static final String FIXED_VERSION = "314.0.0";
+  private static final String FIXED_VERSION = "377.0.0";
   private static final Map<String, String> EMPTY_MAP = Collections.emptyMap();
   private final MessageCollector testListener = new MessageCollector();
   private final ProgressListener testProgressListener = new NullProgressListener();


### PR DESCRIPTION
Can't be the latest version because `ManagedCloudSdkTest.testManagedCloudSdk_latest()` tries to "downgrade" to the fixed version, and then upgrades to latest, so they can't be the same.