### PR TITLE
Compile to java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,8 @@
             <version>3.10.1</version>
             <configuration>
               <!-- For Java 8, the plugin is overridden below, without errorprone -->
-              <release>11</release>
+              <source>1.8</source>
+              <target>1.8</target>
               <showDeprecation>true</showDeprecation>
               <showWarnings>true</showWarnings>
               <annotationProcessorPaths>


### PR DESCRIPTION
I introduced an unintented target Java version upgrade when updating to compile-time Java 17 compatibility.