### PR TITLE
Bugfix: fix `StringIndexOutOfBoundsException` from Crash report.

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/operations/cloudsdk/PathResolver.java
+++ b/src/main/java/com/google/cloud/tools/appengine/operations/cloudsdk/PathResolver.java
@@ -116,7 +116,7 @@ public class PathResolver implements CloudSdkResolver {
   @VisibleForTesting
   static String unquote(String path) {
     if (path.startsWith("\"")) {
-      path = path.substring(1, path.length() - 1);
+      path = path.substring(1);
     }
     if (path.endsWith("\"")) {
       path = path.substring(0, path.length() - 1);


### PR DESCRIPTION
Fix following exception:

```
    java.lang.StringIndexOutOfBoundsException: begin 1, end 0, length 1
            at java.base/java.lang.String.checkBoundsBeginEnd(String.java:3319)
            at java.base/java.lang.String.substring(String.java:1874)
            at com.google.cloud.tools.appengine.operations.cloudsdk.PathResolver.unquote(PathResolver.java:119)
            at com.google.cloud.tools.appengine.operations.cloudsdk.PathResolver.getLocationsFromPath(PathResolver.java:93)
```