### PR TITLE
chore: Allow custom JDK version for Dev Server

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/configuration/RunConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/configuration/RunConfiguration.java
@@ -34,6 +34,8 @@ public class RunConfiguration {
   @Nullable private final Map<String, String> environment;
   @Nullable private final List<String> additionalArguments;
   @Nullable private final String projectId;
+  // Allow custom JDK version to be set
+  @Nullable private final String projectJDKVersion;
 
   private RunConfiguration(
       List<Path> services,
@@ -44,7 +46,8 @@ public class RunConfiguration {
       @Nullable String defaultGcsBucketName,
       @Nullable Map<String, String> environment,
       @Nullable List<String> additionalArguments,
-      @Nullable String projectId) {
+      @Nullable String projectId,
+      @Nullable String projectJDKVersion) {
     this.services = services;
     this.host = host;
     this.port = port;
@@ -54,6 +57,7 @@ public class RunConfiguration {
     this.environment = environment;
     this.additionalArguments = additionalArguments;
     this.projectId = projectId;
+    this.projectJDKVersion = projectJDKVersion;
   }
 
   /**
@@ -114,6 +118,15 @@ public class RunConfiguration {
     return projectId;
   }
 
+  /**
+   * Gets the Custom Project JDK Version users set. This is in the format of
+   * `java.specification.version`'s System Property
+   */
+  @Nullable
+  public String getProjectJDKVersion() {
+    return projectJDKVersion;
+  }
+
   public static Builder builder(List<Path> services) {
     return new Builder(services);
   }
@@ -128,6 +141,7 @@ public class RunConfiguration {
     @Nullable private Map<String, String> environment;
     @Nullable private List<String> additionalArguments;
     @Nullable private String projectId;
+    @Nullable private String projectJDKVersion;
 
     private Builder(List<Path> services) {
       Preconditions.checkNotNull(services);
@@ -178,6 +192,11 @@ public class RunConfiguration {
       return this;
     }
 
+    public Builder projectJDKVersion(@Nullable String projectJDKVersion) {
+      this.projectJDKVersion = projectJDKVersion;
+      return this;
+    }
+
     /** Build a {@link RunConfiguration}. */
     public RunConfiguration build() {
       return new RunConfiguration(
@@ -189,7 +208,8 @@ public class RunConfiguration {
           defaultGcsBucketName,
           environment,
           additionalArguments,
-          projectId);
+          projectId,
+          projectJDKVersion);
     }
   }
 
@@ -204,7 +224,8 @@ public class RunConfiguration {
             .host(host)
             .jvmFlags(getJvmFlags())
             .port(port)
-            .projectId(projectId);
+            .projectId(projectId)
+            .projectJDKVersion(projectJDKVersion);
     return builder;
   }
 }

--- a/src/main/java/com/google/cloud/tools/appengine/configuration/RunConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/configuration/RunConfiguration.java
@@ -119,8 +119,8 @@ public class RunConfiguration {
   }
 
   /**
-   * Gets the Custom Project JDK Version users set. This value is expected to be in the format of
-   * `java.specification.version`'s System Property.
+   * Returns the Custom Project JDK Version users set. This value is expected to be in the format of
+   * {@code java.specification.version} system property.
    */
   @Nullable
   public String getProjectJdkVersion() {
@@ -192,6 +192,17 @@ public class RunConfiguration {
       return this;
     }
 
+    /**
+     * Allows setting a custom JDK Version. This may be needed when the app engine runtime differs
+     * from runtime in JAVA_HOME. If not set, the Dev Server will use the JDK version found in the
+     * JAVA_HOME.
+     *
+     * <p>See https://github.com/GoogleCloudPlatform/appengine-plugins-core/issues/916 for an
+     * example use case
+     *
+     * @param projectJdkVersion JDK Versions in format of 1.8 or 9+
+     * @return RunConfigurations Builder
+     */
     public Builder projectJdkVersion(@Nullable String projectJdkVersion) {
       this.projectJdkVersion = projectJdkVersion;
       return this;

--- a/src/main/java/com/google/cloud/tools/appengine/configuration/RunConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/configuration/RunConfiguration.java
@@ -35,7 +35,7 @@ public class RunConfiguration {
   @Nullable private final List<String> additionalArguments;
   @Nullable private final String projectId;
   // Allow custom JDK version to be set
-  @Nullable private final String projectJDKVersion;
+  @Nullable private final String projectJdkVersion;
 
   private RunConfiguration(
       List<Path> services,
@@ -47,7 +47,7 @@ public class RunConfiguration {
       @Nullable Map<String, String> environment,
       @Nullable List<String> additionalArguments,
       @Nullable String projectId,
-      @Nullable String projectJDKVersion) {
+      @Nullable String projectJdkVersion) {
     this.services = services;
     this.host = host;
     this.port = port;
@@ -57,7 +57,7 @@ public class RunConfiguration {
     this.environment = environment;
     this.additionalArguments = additionalArguments;
     this.projectId = projectId;
-    this.projectJDKVersion = projectJDKVersion;
+    this.projectJdkVersion = projectJdkVersion;
   }
 
   /**
@@ -123,8 +123,8 @@ public class RunConfiguration {
    * `java.specification.version`'s System Property
    */
   @Nullable
-  public String getProjectJDKVersion() {
-    return projectJDKVersion;
+  public String getProjectJdkVersion() {
+    return projectJdkVersion;
   }
 
   public static Builder builder(List<Path> services) {
@@ -141,7 +141,7 @@ public class RunConfiguration {
     @Nullable private Map<String, String> environment;
     @Nullable private List<String> additionalArguments;
     @Nullable private String projectId;
-    @Nullable private String projectJDKVersion;
+    @Nullable private String projectJdkVersion;
 
     private Builder(List<Path> services) {
       Preconditions.checkNotNull(services);
@@ -192,8 +192,8 @@ public class RunConfiguration {
       return this;
     }
 
-    public Builder projectJDKVersion(@Nullable String projectJDKVersion) {
-      this.projectJDKVersion = projectJDKVersion;
+    public Builder projectJdkVersion(@Nullable String projectJdkVersion) {
+      this.projectJdkVersion = projectJdkVersion;
       return this;
     }
 
@@ -209,7 +209,7 @@ public class RunConfiguration {
           environment,
           additionalArguments,
           projectId,
-          projectJDKVersion);
+          projectJdkVersion);
     }
   }
 
@@ -225,7 +225,7 @@ public class RunConfiguration {
             .jvmFlags(getJvmFlags())
             .port(port)
             .projectId(projectId)
-            .projectJDKVersion(projectJDKVersion);
+            .projectJdkVersion(projectJdkVersion);
     return builder;
   }
 }

--- a/src/main/java/com/google/cloud/tools/appengine/configuration/RunConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/configuration/RunConfiguration.java
@@ -119,8 +119,8 @@ public class RunConfiguration {
   }
 
   /**
-   * Gets the Custom Project JDK Version users set. This is in the format of
-   * `java.specification.version`'s System Property
+   * Gets the Custom Project JDK Version users set. This value is expected to be in the format of
+   * `java.specification.version`'s System Property.
    */
   @Nullable
   public String getProjectJdkVersion() {

--- a/src/main/java/com/google/cloud/tools/appengine/operations/DevServer.java
+++ b/src/main/java/com/google/cloud/tools/appengine/operations/DevServer.java
@@ -153,13 +153,17 @@ public class DevServer {
 
   /**
    * Simple helper function to try and extract the major version specified. Very limited validation
-   * done to ensure that the projectJdkVersion is set properly and the value is decoded with best
+   * is done to ensure that the projectJdkVersion is set properly and the value is decoded with best
    * effort. Expected values should follow the {@code java.specification.version} System Property
    * syntax.
    *
    * <p>Value should be 1.8 or 9+ as the project's minimum supported version is Java 8. The
    * difference in format is due the specification format changing between after Java 8. Java 8 and
    * below is represented as 1.x and Java 9+ is represented as "x" (i.e. 9, 11, 17, 21...).
+   *
+   * <p>Note: Since very minimal validate is done to ensure a proper version is set, some JDK
+   * version values may pass (i.e. 1.8.0_181 -> 8, 1.11.0_181 -> 11, 1.11 -> 1) even if that is not
+   * an expected value.
    *
    * @param projectJdkVersion String value of JDK Version
    * @return the major version of JDK version

--- a/src/main/java/com/google/cloud/tools/appengine/operations/DevServer.java
+++ b/src/main/java/com/google/cloud/tools/appengine/operations/DevServer.java
@@ -152,18 +152,22 @@ public class DevServer {
   }
 
   /**
-   * Simple helper function to try and extract the version specified. Very limited validation done
-   * to ensure that the projectJdkVersion is set properly and the value is decoded with best effort.
-   * Expected values should follow the `java.specification.version` syntax.
+   * Simple helper function to try and extract the major version specified. Very limited validation
+   * done to ensure that the projectJdkVersion is set properly and the value is decoded with best
+   * effort. Expected values should follow the {@code java.specification.version} System Property
+   * syntax.
    *
-   * <p>Format should be 1.8 or 9+ as the project's min version is Java 8
+   * <p>Value should be 1.8 or 9+ as the project's minimum supported version is Java 8. The
+   * difference in format is due the specification format changing between after Java 8. Java 8 and
+   * below is represented as 1.x and Java 9+ is represented as "x" (i.e. 9, 11, 17, 21...).
    *
-   * @param projectJdkVersion String version of JDK Version
-   * @return Integer value of JDK version
+   * @param projectJdkVersion String value of JDK Version
+   * @return the major version of JDK version
    */
   @VisibleForTesting
-  public static int getJdkMajorVersion(String projectJdkVersion) {
+  static int getJdkMajorVersion(String projectJdkVersion) {
     String version = projectJdkVersion;
+    // If it starts with `1.`, expect it to be `1.8`
     if (projectJdkVersion.startsWith("1.")) {
       version = projectJdkVersion.substring(2, 3);
     }

--- a/src/main/java/com/google/cloud/tools/appengine/operations/DevServer.java
+++ b/src/main/java/com/google/cloud/tools/appengine/operations/DevServer.java
@@ -88,7 +88,9 @@ public class DevServer {
     if (jdkVersionString == null) {
       jdkVersionString = JAVA_SPECIFICATION_VERSION.value();
     }
-    int jdkVersion = getJdkVersion(jdkVersionString);
+    int jdkVersion = getJdkMajorVersion(jdkVersionString);
+    log.config(
+        String.format("JDK Version found: %s, Parsed to be %d", jdkVersionString, jdkVersion));
     if (jdkVersion > 8) {
       addJpmsRestrictionArguments(jvmArguments);
     }
@@ -149,12 +151,18 @@ public class DevServer {
     }
   }
 
-  // Simple helper function to try and extract the version specified.
-  // Very limited validation done to ensure that the projectJdkVersion is set
-  // properly by the customer and the value is decoded with best effort.
-  // Expected values should follow the `java.specification.version` syntax
-  private int getJdkVersion(String projectJdkVersion) {
-    // Format should be 1.8 or 9+ as the project's min version is Java 8
+  /**
+   * Simple helper function to try and extract the version specified. Very limited validation done
+   * to ensure that the projectJdkVersion is set properly and the value is decoded with best effort.
+   * Expected values should follow the `java.specification.version` syntax.
+   *
+   * <p>Format should be 1.8 or 9+ as the project's min version is Java 8
+   *
+   * @param projectJdkVersion String version of JDK Version
+   * @return Integer value of JDK version
+   */
+  @VisibleForTesting
+  public static int getJdkMajorVersion(String projectJdkVersion) {
     String version = projectJdkVersion;
     if (projectJdkVersion.startsWith("1.")) {
       version = projectJdkVersion.substring(2, 3);
@@ -167,7 +175,7 @@ public class DevServer {
   }
 
   private void addJpmsRestrictionArguments(List<String> jvmArguments) {
-    // Due to JPMS restrictions, Java11 or later need more flags:
+    // Due to JPMS restrictions, Java 9 or later need more flags:
     jvmArguments.add("--add-opens");
     jvmArguments.add("java.base/java.net=ALL-UNNAMED");
     jvmArguments.add("--add-opens");

--- a/src/main/java/com/google/cloud/tools/appengine/operations/DevServer.java
+++ b/src/main/java/com/google/cloud/tools/appengine/operations/DevServer.java
@@ -82,14 +82,14 @@ public class DevServer {
       jvmArguments.addAll(config.getJvmFlags());
     }
 
-    if (!JAVA_SPECIFICATION_VERSION.value().equals("1.8")) {
-      // Due to JPMS restrictions, Java11 or later need more flags:
-      jvmArguments.add("--add-opens");
-      jvmArguments.add("java.base/java.net=ALL-UNNAMED");
-      jvmArguments.add("--add-opens");
-      jvmArguments.add("java.base/sun.net.www.protocol.http=ALL-UNNAMED");
-      jvmArguments.add("--add-opens");
-      jvmArguments.add("java.base/sun.net.www.protocol.https=ALL-UNNAMED");
+    // Check if the RunConfiguration has the Project JDK Version defined first
+    // The custom value takes priority over the System Property
+    String jdkVersion = config.getProjectJDKVersion();
+    if (jdkVersion == null) {
+      jdkVersion = JAVA_SPECIFICATION_VERSION.value();
+    }
+    if (!jdkVersion.equals("1.8")) {
+      addJPMSRestrictionArguments(jvmArguments);
     }
 
     arguments.addAll(DevAppServerArgs.get("default_gcs_bucket", config.getDefaultGcsBucketName()));
@@ -146,6 +146,16 @@ public class DevServer {
     } catch (ProcessHandlerException | IOException ex) {
       throw new AppEngineException(ex);
     }
+  }
+
+  private void addJPMSRestrictionArguments(List<String> jvmArguments) {
+    // Due to JPMS restrictions, Java11 or later need more flags:
+    jvmArguments.add("--add-opens");
+    jvmArguments.add("java.base/java.net=ALL-UNNAMED");
+    jvmArguments.add("--add-opens");
+    jvmArguments.add("java.base/sun.net.www.protocol.http=ALL-UNNAMED");
+    jvmArguments.add("--add-opens");
+    jvmArguments.add("java.base/sun.net.www.protocol.https=ALL-UNNAMED");
   }
 
   /** Stops the local development server. */

--- a/src/main/java/com/google/cloud/tools/appengine/operations/DevServer.java
+++ b/src/main/java/com/google/cloud/tools/appengine/operations/DevServer.java
@@ -84,11 +84,11 @@ public class DevServer {
 
     // Check if the RunConfiguration has the Project JDK Version defined first
     // The custom value takes priority over the System Property
-    String jdkString = config.getProjectJdkVersion();
-    if (jdkString == null) {
-      jdkString = JAVA_SPECIFICATION_VERSION.value();
+    String jdkVersionString = config.getProjectJdkVersion();
+    if (jdkVersionString == null) {
+      jdkVersionString = JAVA_SPECIFICATION_VERSION.value();
     }
-    int jdkVersion = getJdkVersion(jdkString);
+    int jdkVersion = getJdkVersion(jdkVersionString);
     if (jdkVersion > 8) {
       addJpmsRestrictionArguments(jvmArguments);
     }
@@ -154,7 +154,8 @@ public class DevServer {
   // properly by the customer and the value is decoded with best effort.
   // Expected values should follow the `java.specification.version` syntax
   private int getJdkVersion(String projectJdkVersion) {
-    String version = null;
+    // Format may be 1.x, 9.x.x, or 12
+    String version = projectJdkVersion;
     if (projectJdkVersion.startsWith("1.")) {
       version = projectJdkVersion.substring(2, 3);
     } else {

--- a/src/main/java/com/google/cloud/tools/appengine/operations/DevServer.java
+++ b/src/main/java/com/google/cloud/tools/appengine/operations/DevServer.java
@@ -154,15 +154,10 @@ public class DevServer {
   // properly by the customer and the value is decoded with best effort.
   // Expected values should follow the `java.specification.version` syntax
   private int getJdkVersion(String projectJdkVersion) {
-    // Format may be 1.x, 9.x.x, or 12
+    // Format should be 1.8 or 9+ as the project's min version is Java 8
     String version = projectJdkVersion;
     if (projectJdkVersion.startsWith("1.")) {
       version = projectJdkVersion.substring(2, 3);
-    } else {
-      int dot = projectJdkVersion.indexOf(".");
-      if (dot != -1) {
-        version = projectJdkVersion.substring(0, dot);
-      }
     }
     try {
       return Integer.parseInt(version);

--- a/src/test/java/com/google/cloud/tools/appengine/operations/DevServerJava8Test.java
+++ b/src/test/java/com/google/cloud/tools/appengine/operations/DevServerJava8Test.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.appengine.operations;
 
 import static com.google.common.base.StandardSystemProperty.JAVA_SPECIFICATION_VERSION;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -540,18 +539,5 @@ public class DevServerJava8Test {
   @Test
   public void testGetGaeRuntimeJava_isNotJava8() {
     Assert.assertEquals("java7", DevServer.getGaeRuntimeJava(false));
-  }
-
-  @Test
-  public void testInvalidJDKVersion_throwsIllegalArgumentException() {
-    RunConfiguration configuration =
-        RunConfiguration.builder(ImmutableList.of(java8Service)).projectJdkVersion("abc").build();
-    assertThrows(IllegalArgumentException.class, () -> devServer.run(configuration));
-
-    RunConfiguration configuration1 = configuration.toBuilder().projectJdkVersion("as37.5").build();
-    assertThrows(IllegalArgumentException.class, () -> devServer.run(configuration1));
-
-    RunConfiguration configuration2 = configuration.toBuilder().projectJdkVersion("1.b8c").build();
-    assertThrows(IllegalArgumentException.class, () -> devServer.run(configuration2));
   }
 }

--- a/src/test/java/com/google/cloud/tools/appengine/operations/DevServerJava8Test.java
+++ b/src/test/java/com/google/cloud/tools/appengine/operations/DevServerJava8Test.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.appengine.operations;
 
 import static com.google.common.base.StandardSystemProperty.JAVA_SPECIFICATION_VERSION;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -135,7 +136,6 @@ public class DevServerJava8Test {
 
   @Test
   public void testPrepareCommand_allFlags() throws Exception {
-
     RunConfiguration configuration =
         Mockito.spy(
             RunConfiguration.builder(ImmutableList.of(java8Service))
@@ -148,7 +148,7 @@ public class DevServerJava8Test {
                 .projectId("my-project")
                 .environment(ImmutableMap.of("ENV_NAME", "ENV_VAL"))
                 .additionalArguments(Arrays.asList("--ARG1", "--ARG2"))
-                .projectJDKVersion("11")
+                .projectJdkVersion("1.8")
                 .build());
 
     SpyVerifier.newVerifier(configuration).verifyAllValuesNotNull();
@@ -540,5 +540,18 @@ public class DevServerJava8Test {
   @Test
   public void testGetGaeRuntimeJava_isNotJava8() {
     Assert.assertEquals("java7", DevServer.getGaeRuntimeJava(false));
+  }
+
+  @Test
+  public void testInvalidJDKVersion_throwsIllegalArgumentException() {
+    RunConfiguration configuration =
+        RunConfiguration.builder(ImmutableList.of(java8Service)).projectJdkVersion("abc").build();
+    assertThrows(IllegalArgumentException.class, () -> devServer.run(configuration));
+
+    RunConfiguration configuration1 = configuration.toBuilder().projectJdkVersion("as37.5").build();
+    assertThrows(IllegalArgumentException.class, () -> devServer.run(configuration1));
+
+    RunConfiguration configuration2 = configuration.toBuilder().projectJdkVersion("1.b8c").build();
+    assertThrows(IllegalArgumentException.class, () -> devServer.run(configuration2));
   }
 }

--- a/src/test/java/com/google/cloud/tools/appengine/operations/DevServerJava8Test.java
+++ b/src/test/java/com/google/cloud/tools/appengine/operations/DevServerJava8Test.java
@@ -148,6 +148,7 @@ public class DevServerJava8Test {
                 .projectId("my-project")
                 .environment(ImmutableMap.of("ENV_NAME", "ENV_VAL"))
                 .additionalArguments(Arrays.asList("--ARG1", "--ARG2"))
+                .projectJDKVersion("11")
                 .build());
 
     SpyVerifier.newVerifier(configuration).verifyAllValuesNotNull();

--- a/src/test/java/com/google/cloud/tools/appengine/operations/DevServerJava9OrAboveTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/operations/DevServerJava9OrAboveTest.java
@@ -895,29 +895,29 @@ public class DevServerJava9OrAboveTest {
   }
 
   @Test
-  public void testValidJDKVersion() throws AppEngineException {
-    RunConfiguration configuration =
-        RunConfiguration.builder(ImmutableList.of(java8Service)).projectJdkVersion("1.8").build();
-    devServer.run(configuration);
+  public void testGetJdkVersion_isValid() {
+    Assert.assertEquals(8, DevServer.getJdkMajorVersion("1.8"));
+    Assert.assertEquals(9, DevServer.getJdkMajorVersion("9"));
+    Assert.assertEquals(11, DevServer.getJdkMajorVersion("11"));
+    Assert.assertEquals(17, DevServer.getJdkMajorVersion("17"));
+    Assert.assertEquals(21, DevServer.getJdkMajorVersion("21"));
 
-    RunConfiguration configuration1 =
-        RunConfiguration.builder(ImmutableList.of(java8Service)).projectJdkVersion("9").build();
-    devServer.run(configuration1);
+    // This would be accepted for Java 8, but should expect them to be in
+    // `java.specification.version` syntax
+    Assert.assertEquals(8, DevServer.getJdkMajorVersion("1.8.0_181-google-v7"));
   }
 
   @Test
-  public void testInvalidJDKVersion_throwsIllegalArgumentException() {
-    RunConfiguration configuration =
-        RunConfiguration.builder(ImmutableList.of(java8Service)).projectJdkVersion("12abc").build();
-    assertThrows(IllegalArgumentException.class, () -> devServer.run(configuration));
+  public void testGetJdkVersion_isInvalid_throwsIllegalArgumentException() {
+    // May be valid JDK versions names, but should expect them in `java.specification.version`
+    // syntax
+    assertThrows(IllegalArgumentException.class, () -> DevServer.getJdkMajorVersion("11.0.6"));
+    assertThrows(IllegalArgumentException.class, () -> DevServer.getJdkMajorVersion("17.0.11"));
+    assertThrows(
+        IllegalArgumentException.class, () -> DevServer.getJdkMajorVersion("11.0.0_181-google-v7"));
 
-    RunConfiguration configuration1 = configuration.toBuilder().projectJdkVersion("as37.5").build();
-    assertThrows(IllegalArgumentException.class, () -> devServer.run(configuration1));
-
-    RunConfiguration configuration2 = configuration.toBuilder().projectJdkVersion("1.a8s").build();
-    assertThrows(IllegalArgumentException.class, () -> devServer.run(configuration2));
-
-    RunConfiguration configuration3 = configuration.toBuilder().projectJdkVersion("12.42").build();
-    assertThrows(IllegalArgumentException.class, () -> devServer.run(configuration3));
+    assertThrows(IllegalArgumentException.class, () -> DevServer.getJdkMajorVersion("12abc"));
+    assertThrows(IllegalArgumentException.class, () -> DevServer.getJdkMajorVersion("as37.5"));
+    assertThrows(IllegalArgumentException.class, () -> DevServer.getJdkMajorVersion("1.a8s"));
   }
 }

--- a/src/test/java/com/google/cloud/tools/appengine/operations/DevServerJava9OrAboveTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/operations/DevServerJava9OrAboveTest.java
@@ -902,9 +902,10 @@ public class DevServerJava9OrAboveTest {
     Assert.assertEquals(17, DevServer.getJdkMajorVersion("17"));
     Assert.assertEquals(21, DevServer.getJdkMajorVersion("21"));
 
-    // This would be accepted for Java 8, but should expect them to be in
+    // These would be accepted for Java 8, but should expect them to be in
     // `java.specification.version` syntax
     Assert.assertEquals(8, DevServer.getJdkMajorVersion("1.8.0_181-google-v7"));
+    Assert.assertEquals(1, DevServer.getJdkMajorVersion("1.11"));
   }
 
   @Test

--- a/src/test/java/com/google/cloud/tools/appengine/operations/DevServerJava9OrAboveTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/operations/DevServerJava9OrAboveTest.java
@@ -149,7 +149,7 @@ public class DevServerJava9OrAboveTest {
                 .projectId("my-project")
                 .environment(ImmutableMap.of("ENV_NAME", "ENV_VAL"))
                 .additionalArguments(Arrays.asList("--ARG1", "--ARG2"))
-                .projectJDKVersion("11")
+                .projectJdkVersion("11")
                 .build());
 
     SpyVerifier.newVerifier(configuration).verifyAllValuesNotNull();
@@ -216,7 +216,7 @@ public class DevServerJava9OrAboveTest {
                 .projectId("my-project")
                 .environment(ImmutableMap.of("ENV_NAME", "ENV_VAL"))
                 .additionalArguments(Arrays.asList("--ARG1", "--ARG2"))
-                .projectJDKVersion("1.8")
+                .projectJdkVersion("1.8")
                 .build());
 
     SpyVerifier.newVerifier(configuration).verifyAllValuesNotNull();
@@ -294,7 +294,7 @@ public class DevServerJava9OrAboveTest {
   public void testPrepareCommand_booleanFlags_projectJDKVersionJava8()
       throws AppEngineException, ProcessHandlerException, IOException {
     RunConfiguration configuration =
-        RunConfiguration.builder(ImmutableList.of(java8Service)).projectJDKVersion("1.8").build();
+        RunConfiguration.builder(ImmutableList.of(java8Service)).projectJdkVersion("1.8").build();
 
     List<String> expectedFlags =
         ImmutableList.of(
@@ -349,7 +349,7 @@ public class DevServerJava9OrAboveTest {
       throws AppEngineException, ProcessHandlerException, IOException {
 
     RunConfiguration configuration =
-        RunConfiguration.builder(ImmutableList.of(java8Service)).projectJDKVersion("1.8").build();
+        RunConfiguration.builder(ImmutableList.of(java8Service)).projectJdkVersion("1.8").build();
 
     List<String> expectedFlags =
         ImmutableList.of(
@@ -407,7 +407,7 @@ public class DevServerJava9OrAboveTest {
       throws AppEngineException, ProcessHandlerException, IOException {
 
     RunConfiguration configuration =
-        RunConfiguration.builder(ImmutableList.of(java7Service)).projectJDKVersion("1.8").build();
+        RunConfiguration.builder(ImmutableList.of(java7Service)).projectJdkVersion("1.8").build();
 
     List<String> expectedFlags =
         ImmutableList.of(
@@ -461,7 +461,7 @@ public class DevServerJava9OrAboveTest {
 
     RunConfiguration configuration =
         RunConfiguration.builder(ImmutableList.of(java7Service, java8Service))
-            .projectJDKVersion("1.8")
+            .projectJdkVersion("1.8")
             .build();
 
     List<String> expectedFlags =
@@ -524,7 +524,7 @@ public class DevServerJava9OrAboveTest {
       throws AppEngineException, ProcessHandlerException, IOException {
     RunConfiguration configuration =
         RunConfiguration.builder(ImmutableList.of(java8Service1EnvVars))
-            .projectJDKVersion("1.8")
+            .projectJdkVersion("1.8")
             .build();
 
     List<String> expectedFlags =
@@ -597,7 +597,7 @@ public class DevServerJava9OrAboveTest {
           throws AppEngineException, ProcessHandlerException, IOException {
     RunConfiguration configuration =
         RunConfiguration.builder(ImmutableList.of(java8Service1EnvVars, java8Service2EnvVars))
-            .projectJDKVersion("1.8")
+            .projectJdkVersion("1.8")
             .build();
 
     List<String> expectedFlags =
@@ -673,7 +673,7 @@ public class DevServerJava9OrAboveTest {
 
     RunConfiguration configuration =
         RunConfiguration.builder(ImmutableList.of(java7Service))
-            .projectJDKVersion("1.8")
+            .projectJdkVersion("1.8")
             .environment(clientEnvironmentVariables)
             .build();
 
@@ -752,7 +752,7 @@ public class DevServerJava9OrAboveTest {
 
     RunConfiguration configuration =
         RunConfiguration.builder(ImmutableList.of(java8Service1EnvVars))
-            .projectJDKVersion("1.8")
+            .projectJdkVersion("1.8")
             .environment(clientEnvironmentVariables)
             .build();
 

--- a/src/test/java/com/google/cloud/tools/appengine/operations/DevServerJava9OrAboveTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/operations/DevServerJava9OrAboveTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.appengine.operations;
 
 import static com.google.common.base.StandardSystemProperty.JAVA_SPECIFICATION_VERSION;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -891,5 +892,32 @@ public class DevServerJava9OrAboveTest {
   @Test
   public void testGetGaeRuntimeJava_isNotJava8() {
     Assert.assertEquals("java7", DevServer.getGaeRuntimeJava(false));
+  }
+
+  @Test
+  public void testValidJDKVersion() throws AppEngineException {
+    RunConfiguration configuration =
+        RunConfiguration.builder(ImmutableList.of(java8Service)).projectJdkVersion("1.8").build();
+    devServer.run(configuration);
+
+    RunConfiguration configuration1 =
+        RunConfiguration.builder(ImmutableList.of(java8Service)).projectJdkVersion("9").build();
+    devServer.run(configuration1);
+  }
+
+  @Test
+  public void testInvalidJDKVersion_throwsIllegalArgumentException() {
+    RunConfiguration configuration =
+        RunConfiguration.builder(ImmutableList.of(java8Service)).projectJdkVersion("12abc").build();
+    assertThrows(IllegalArgumentException.class, () -> devServer.run(configuration));
+
+    RunConfiguration configuration1 = configuration.toBuilder().projectJdkVersion("as37.5").build();
+    assertThrows(IllegalArgumentException.class, () -> devServer.run(configuration1));
+
+    RunConfiguration configuration2 = configuration.toBuilder().projectJdkVersion("1.a8s").build();
+    assertThrows(IllegalArgumentException.class, () -> devServer.run(configuration2));
+
+    RunConfiguration configuration3 = configuration.toBuilder().projectJdkVersion("12.42").build();
+    assertThrows(IllegalArgumentException.class, () -> devServer.run(configuration3));
   }
 }

--- a/src/test/java/com/google/cloud/tools/appengine/operations/DevServerJava9OrAboveTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/operations/DevServerJava9OrAboveTest.java
@@ -911,7 +911,7 @@ public class DevServerJava9OrAboveTest {
   public void testGetJdkVersion_isInvalid_throwsIllegalArgumentException() {
     // May be valid JDK versions names, but should expect them in `java.specification.version`
     // syntax
-    assertThrows(IllegalArgumentException.class, () -> DevServer.getJdkMajorVersion("11.0.6"));
+    assertThrows(IllegalArgumentException.class, () -> DevServer.getJdkMajorVersion("11.0.0"));
     assertThrows(IllegalArgumentException.class, () -> DevServer.getJdkMajorVersion("17.0.11"));
     assertThrows(
         IllegalArgumentException.class, () -> DevServer.getJdkMajorVersion("11.0.0_181-google-v7"));


### PR DESCRIPTION
Thank you for your interest in contributing! For general guidelines, please refer to
the [contributing guide](https://github.com/GoogleCloudPlatform/appengine-plugins-core/blob/master/CONTRIBUTING.md).

Before submitting a pull request, please make sure to:

- [x] Identify an existing [issue](https://github.com/GoogleCloudPlatform/appengine-plugins-core/issues) to associate
  with your proposed change,
  or [file a new issue](https://github.com/GoogleCloudPlatform/appengine-plugins-core/issues/new).
- [x] Describe any implementation plans in the issue and wait for a review from the repository maintainers.

Allow users to allow a pass in the JDK version as part of the DevServer's Run Configurations. This may be different from the JDK specified in JAVA_HOME. By default, this plugin should generally be using the `java.specification.version` System Property. If needed, customers can use the Run Configuration's JDK version to override.

Fixes #916 🛠️
