### PR TITLE
chore: add Google's Maven Central mirror

### DIFF
--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -5,6 +5,9 @@ echo %JAVA_HOME%
 
 cd github/appengine-plugins-core
 
+if not exist "%HOME%\.m2" mkdir "%HOME%\.m2"
+copy settings.xml "%HOME%\.m2"
+
 call gcloud.cmd components update --quiet
 call gcloud.cmd components install app-engine-java --quiet
 

--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -14,6 +14,10 @@ unset JAVA_TOOL_OPTIONS
 update-java-alternatives -s /usr/lib/jvm/java-1.8.0-openjdk-amd64
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
 
+# Use GCP Maven Mirror
+mkdir -p ${HOME}/.m2
+cp settings.xml ${HOME}/.m2
+
 if [ "$EUID" -ne 0 ]
 then
   # not running as root

--- a/kokoro/continuous_mac.sh
+++ b/kokoro/continuous_mac.sh
@@ -10,9 +10,10 @@ export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-8-latest/Contents/Home
 gcloud components update
 gcloud components install app-engine-java
 
+cd github/appengine-plugins-core
+
 # Use GCP Maven Mirror
 mkdir -p ${HOME}/.m2
 cp settings.xml ${HOME}/.m2
 
-cd github/appengine-plugins-core
 ./mvnw clean install cobertura:cobertura -B -U

--- a/kokoro/continuous_mac.sh
+++ b/kokoro/continuous_mac.sh
@@ -10,5 +10,9 @@ export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-8-latest/Contents/Home
 gcloud components update
 gcloud components install app-engine-java
 
+# Use GCP Maven Mirror
+mkdir -p ${HOME}/.m2
+cp settings.xml ${HOME}/.m2
+
 cd github/appengine-plugins-core
 ./mvnw clean install cobertura:cobertura -B -U

--- a/kokoro/release_build.sh
+++ b/kokoro/release_build.sh
@@ -9,6 +9,11 @@ sudo -E /opt/google-cloud-sdk/bin/gcloud components update -q
 sudo -E /opt/google-cloud-sdk/bin/gcloud components install app-engine-java -q
 
 cd github/appengine-plugins-core
+
+# Use GCP Maven Mirror
+mkdir -p ${HOME}/.m2
+cp settings.xml ${HOME}/.m2
+
 mvn -Prelease -B -U verify -Dtest=!FilePermissionsTest
 
 # copy pom with the name expected in the Maven repository

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ Copyright 2022 Google LLC.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <!-- Google's Maven Central mirror for Americas
+       https://maven-central.storage.googleapis.com/index.html
+      -->
+      <id>google-maven-central</id>
+      <name>GCS Maven Central mirror</name>
+      <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>


### PR DESCRIPTION
This will hopefully eliminate Maven artifact download flakiness in Kokoro CI jobs.