### PR TITLE
ci: maven-gpg-plugin 3.2.7

### DIFF
--- a/app-maven-plugin/pom.xml
+++ b/app-maven-plugin/pom.xml
@@ -430,7 +430,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/appengine-plugins-core/pom.xml
+++ b/appengine-plugins-core/pom.xml
@@ -418,7 +418,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
This version matches java-shared-config's version:
https://github.com/googleapis/java-shared-config/blob/e0b51da934de8de156e0fc7d53123983c855e31b/native-image-shared-config/pom.xml#L192C22-L192C27.

This should resolve `gpg: signing failed: No pinentry` error in b/452971373.