### PR TITLE
ci: root pom.xml depends on appengine-plugins-core

### DIFF
--- a/app-maven-plugin/pom.xml
+++ b/app-maven-plugin/pom.xml
@@ -396,7 +396,7 @@
     <profile>
       <!-- Release to Sonatype (Maven Central) needs nexus-staging-maven-plugin but OSS Exit Gate
           does not require nexus-staging-maven-plugin -->
-      <id>nexus-staging-plugin</id>
+      <id>release-sonatype</id>
       <activation>
         <property>
           <name>performRelease</name>

--- a/appengine-plugins-core/pom.xml
+++ b/appengine-plugins-core/pom.xml
@@ -384,7 +384,7 @@
     <profile>
       <!-- Release to Sonatype (Maven Central) needs nexus-staging-maven-plugin but OSS Exit Gate
           does not require nexus-staging-maven-plugin -->
-      <id>nexus-staging-plugin</id>
+      <id>release-sonatype</id>
       <activation>
         <property>
           <name>performRelease</name>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,17 @@
     <module>appengine-plugins-core</module>
     <module>app-maven-plugin</module>
   </modules>
+
+  <dependencies>
+    <!-- This root module does not actually use the appengine-plugins-core,
+      but it executes the Gradle in app-gradle-plugin folder, which needs
+      appengine-plugins-core -->
+    <dependency>
+      <groupId>com.google.cloud.tools</groupId>
+      <artifactId>appengine-plugins-core</artifactId>
+      <version>0.13.4-SNAPSHOT</version><!-- {x-version-update:appengine-plugins-core:current} -->
+    </dependency>
+  </dependencies>
   <!-- Do not deploy the aggregator POM -->
   <build>
     <plugins>
@@ -115,6 +126,25 @@
                   <goal>exec</goal>
                 </goals>
               </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>3.1.1</version>
+            <executions>
               <execution>
                 <id>deploy</id>
                 <!-- This execution allows the root Maven project to deploy the


### PR DESCRIPTION
The dependency declaration sets the order of the module execution. The appengine-plugins-core needs to be installed before the root pom.xml executes Gradle for app-gradle-plugin folder. Note that the root pom.xml is not published during a release.

This also changes the profile name "release-sonatype" so that the release script (shared) deactivates the old sonatype plugin. The release script has a flag to deactivate the "release-sonatype" profile.

This should address b/452971373#comment7.
